### PR TITLE
feat: expose facets in search endpoint

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -5,7 +5,7 @@ from app.routes.mocks import router as mocks_router
 from app.routes.web_auth import router as auth_router
 
 from .recommend import recommend_post
-from .search import search_get
+from .search import search_post
 from .util import internal_api_router
 
 web_api_router = APIRouter()

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -2,17 +2,18 @@
 
 from json import JSONDecodeError
 
-from fastapi import HTTPException, Query
+from fastapi import Body, HTTPException, Query
 from httpx import AsyncClient
 
+from app.schemas.search_request import SearchRequest
 from app.solr.operations import search
 
 from .util import DEFAULT_SORT, internal_api_router
 
 
 # pylint: disable=too-many-arguments
-@internal_api_router.get("/search", name="apis:get-search")
-async def search_get(
+@internal_api_router.post("/search", name="apis:post-search")
+async def search_post(
     collection: str = Query(..., description="Collection"),
     q: str = Query(..., description="Free-form query string"),
     qf: list[str] = Query([], description="Query fields", example=["authors", "title"]),
@@ -26,6 +27,7 @@ async def search_get(
     ),
     rows: int = Query(10, description="Row count", gte=0, le=100),
     cursor: str = Query("*", description="Cursor"),
+    request: SearchRequest = Body(..., description="Request body"),
 ):
     """
     Do a search against the specified collection.
@@ -34,6 +36,9 @@ async def search_get(
     https://solr.apache.org/guide/8_11/query-syntax-and-parsing.html.
     Paging is cursor-based, see
     https://solr.apache.org/guide/8_11/pagination-of-results.html#fetching-a-large-number-of-sorted-results-cursors.
+
+    Facets can be specified in the request body, they allow a subset of functionality from
+    https://solr.apache.org/guide/8_11/json-facet-api.html.
     """
     async with AsyncClient() as client:
         response = await search(
@@ -45,6 +50,7 @@ async def search_get(
             sort=sort + DEFAULT_SORT,
             rows=rows,
             cursor=cursor,
+            facets=request.facets,
         )
     if response.is_error:
         try:
@@ -53,7 +59,12 @@ async def search_get(
             detail = None
         raise HTTPException(status_code=response.status_code, detail=detail)
     res_json = response.json()
-    return {
+    out = {
         "results": res_json["response"]["docs"],
         "nextCursorMark": res_json["nextCursorMark"],
     }
+    try:
+        out["facets"] = res_json["facets"]
+    except KeyError:
+        pass
+    return out

--- a/backend/app/schemas/recommend_request.py
+++ b/backend/app/schemas/recommend_request.py
@@ -1,4 +1,4 @@
-"""Request bodies"""
+"""Recommend request schema"""
 from datetime import datetime
 
 from pydantic import BaseModel

--- a/backend/app/schemas/search_request.py
+++ b/backend/app/schemas/search_request.py
@@ -1,0 +1,29 @@
+"""Search request schema"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class TermsFacet(BaseModel):
+    """
+    The TermsFacet schema.
+
+    It includes selected fields from https://solr.apache.org/guide/8_11/json-facet-api.html.
+    """
+
+    type: Literal["terms"]
+    field: str
+    offset: Optional[int]
+    limit: Optional[int]
+    sort: Optional[str]
+    mincount: Optional[int]
+    missing: Optional[bool]
+
+
+class SearchRequest(BaseModel):
+    """The search request specification"""
+
+    facets: Optional[dict[str, TermsFacet]]

--- a/backend/tests/test_apis.py
+++ b/backend/tests/test_apis.py
@@ -7,14 +7,16 @@ from starlette.status import HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
-async def test_search_get_empty(app: FastAPI, client: AsyncClient) -> None:
-    res = await client.get(app.url_path_for("apis:get-search"))
+async def test_search_post_empty(app: FastAPI, client: AsyncClient) -> None:
+    res = await client.post(app.url_path_for("apis:post-search"), json={})
     assert res.status_code == HTTP_422_UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
-async def test_search_get(app: FastAPI, client: AsyncClient) -> None:
-    res = await client.get(
-        app.url_path_for("apis:get-search"), params={"q": "sth", "collection": "foo"}
+async def test_search_post(app: FastAPI, client: AsyncClient) -> None:
+    res = await client.post(
+        app.url_path_for("apis:post-search"),
+        params={"q": "sth", "collection": "foo"},
+        json={},
     )
     assert res.status_code == HTTP_404_NOT_FOUND


### PR DESCRIPTION
Switch to Solr's JSON Request API and use JSON Facet API
for the facets. In this way all parameters are passed to Solr
by JSON request body.

Closes: #25.