### PR TITLE
feat: mapping of access rights

### DIFF
--- a/transform/all_collection/spark/process.py
+++ b/transform/all_collection/spark/process.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
                 df_trans = trans.trans_map[col_name](
                     df, harvested_schemas[col_name], spark
                 )
-            except ValueError:
+            except (ValueError, AssertionError):
                 print_errors("transform_fail", failed_files, col_name, file, logger)
                 continue
 

--- a/transform/all_collection/spark/schemas/harvested_props_schemas.py
+++ b/transform/all_collection/spark/schemas/harvested_props_schemas.py
@@ -20,17 +20,19 @@ __all__ = [
     "harvested_schemas",
 ]
 
+# IMPORTANT keep those schema alphabetical - or write sorting for those
 df_harvested_schema = StructType(
     [
         StructField("author_names", ArrayType(StringType()), True),
         StructField("author_pids", ArrayType(ArrayType(StringType())), True),
-        StructField("sdg", ArrayType(StringType()), True),
-        StructField("open_access", BooleanType(), True),
-        StructField("funder", ArrayType(StringType()), True),
-        StructField("url", ArrayType(StringType()), True),
-        StructField("document_type", ArrayType(StringType()), True),
+        StructField("best_access_right", StringType(), True),
         StructField("country", ArrayType(StringType()), True),
+        StructField("document_type", ArrayType(StringType()), True),
+        StructField("funder", ArrayType(StringType()), True),
+        StructField("open_access", BooleanType(), True),
         StructField("research_community", ArrayType(StringType()), True),
+        StructField("sdg", ArrayType(StringType()), True),
+        StructField("url", ArrayType(StringType()), True),
     ]
 )
 
@@ -38,14 +40,15 @@ pub_harvested_schema = StructType(
     [
         StructField("author_names", ArrayType(StringType()), True),
         StructField("author_pids", ArrayType(ArrayType(StringType())), True),
-        StructField("sdg", ArrayType(StringType()), True),
-        StructField("fos", ArrayType(StringType()), True),
-        StructField("open_access", BooleanType(), True),
-        StructField("funder", ArrayType(StringType()), True),
-        StructField("url", ArrayType(StringType()), True),
-        StructField("document_type", ArrayType(StringType()), True),
+        StructField("best_access_right", StringType(), True),
         StructField("country", ArrayType(StringType()), True),
+        StructField("document_type", ArrayType(StringType()), True),
+        StructField("fos", ArrayType(StringType()), True),
+        StructField("funder", ArrayType(StringType()), True),
+        StructField("open_access", BooleanType(), True),
         StructField("research_community", ArrayType(StringType()), True),
+        StructField("sdg", ArrayType(StringType()), True),
+        StructField("url", ArrayType(StringType()), True),
     ]
 )
 
@@ -53,17 +56,19 @@ soft_harvested_schema = StructType(
     [
         StructField("author_names", ArrayType(StringType()), True),
         StructField("author_pids", ArrayType(ArrayType(StringType())), True),
-        StructField("open_access", BooleanType(), True),
-        StructField("funder", ArrayType(StringType()), True),
-        StructField("url", ArrayType(StringType()), True),
-        StructField("document_type", ArrayType(StringType()), True),
+        StructField("best_access_right", StringType(), True),
         StructField("country", ArrayType(StringType()), True),
+        StructField("document_type", ArrayType(StringType()), True),
+        StructField("funder", ArrayType(StringType()), True),
+        StructField("open_access", BooleanType(), True),
         StructField("research_community", ArrayType(StringType()), True),
+        StructField("url", ArrayType(StringType()), True),
     ]
 )
 
 train_harvested_schema = StructType(
     [
+        StructField("best_access_right", StringType(), True),
         StructField("duration", LongType(), True),
         StructField("open_access", BooleanType(), True),
     ]
@@ -71,8 +76,9 @@ train_harvested_schema = StructType(
 
 ser_harvested_schema = StructType(
     [
-        StructField("open_access", BooleanType(), True),
+        StructField("best_access_right", StringType(), True),
         StructField("geographical_availabilities", StringType(), True),
+        StructField("open_access", BooleanType(), True),
         StructField("resource_geographic_locations", StringType(), True),
     ]
 )

--- a/transform/all_collection/spark/schemas/input_col_name.py
+++ b/transform/all_collection/spark/schemas/input_col_name.py
@@ -3,7 +3,7 @@
 # OAG
 AUTHOR_NAMES = "author_names"
 AUTHOR_PIDS = "author_pids"
-BESTACCESSRIGHT = "bestaccessright"
+BEST_ACCESS_RIGHT = "best_access_right"
 COUNTRY = "country"
 DESCRIPTION = "description"
 DURATION = "duration"

--- a/transform/all_collection/spark/transformations/services_transform.py
+++ b/transform/all_collection/spark/transformations/services_transform.py
@@ -13,6 +13,7 @@ from pyspark.sql.types import StringType, StructType
 from transform.all_collection.spark.utils.join_dfs import join_different_dfs, create_df
 from transform.all_collection.spark.transformations.commons import (
     create_open_access,
+    harvest_best_access_right,
 )
 from transform.all_collection.spark.utils.utils import (
     drop_columns,
@@ -21,6 +22,7 @@ from transform.all_collection.spark.utils.utils import (
 from transform.all_collection.spark.schemas.input_col_name import (
     GEO_AV,
     RESOURCE_GEO_LOC,
+    BEST_ACCESS_RIGHT,
 )
 from transform.all_collection.spark.utils.utils import replace_empty_str
 
@@ -61,19 +63,14 @@ COLS_TO_DROP = (GEO_AV, RESOURCE_GEO_LOC, "public_contacts")
 def transform_services(
     services: DataFrame, harvested_schema: StructType, spark: SparkSession
 ) -> DataFrame:
-    """
-    Required transformations:
-    1) type = service
-    2) rename and cast columns
-    3) Create open_access
-    4) Simplify geographical_availabilities and resource_geographic_locations
-    4) Add OAG + trainings specific columns
-    """
+    """Transform services"""
+    col_name = "service"
     harvested_properties = {}
 
-    services = services.withColumn("type", lit("service"))
+    services = services.withColumn("type", lit(col_name))
     services = rename_and_cast_columns(services)
-    create_open_access(services, harvested_properties, "best_access_right")
+    services = harvest_best_access_right(services, harvested_properties, col_name)
+    create_open_access(harvested_properties[BEST_ACCESS_RIGHT], harvested_properties)
     simplify_geo_properties(services, harvested_properties)
     services = simplify_urls(services)
 

--- a/transform/all_collection/spark/utils/join_dfs.py
+++ b/transform/all_collection/spark/utils/join_dfs.py
@@ -44,6 +44,7 @@ def create_df(
     harvested_properties: Dict, schema: StructType, spark: SparkSession
 ) -> DataFrame:
     """Create dataframe from dict of <name_of_column>: <column_values>"""
+    harvested_properties = dict(sorted(harvested_properties.items()))
     it = iter(harvested_properties.values())
     _len = len(next(it))
     assert all(


### PR DESCRIPTION
closes #225

Mapping as it was in the ticket (right side was mapped to the left side):
```
"Open access": "OPEN", "open_access", "fully_open_access", "open access", "free access", "free access "  - as you can see free access is twice (once with a space at the end) as always trainings data is flawed :)
"Restricted": "RESTRICTED"
"Ordered required": "order_required"
"Login required": "login required"
"Login required on EOSC Pillar, open access on the original resource page": "login required on EOSC Pillar, open access on the original resource page"
"Closed": "CLOSED"
"Embargo": "EMBARGO"
"Other": "other"
```