### PR TITLE
fix: update tags fields

### DIFF
--- a/ui/apps/ui/src/app/collections/data/datasets/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/datasets/adapter.data.ts
@@ -2,7 +2,6 @@ import { IAdapter, IResult } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
 import { IOpenAIREResult } from '../openair.model';
 import { COLLECTION } from './search-metadata.data';
-import moment from 'moment';
 import { toArray } from '@collections/filters-serializers/utils';
 
 export const datasetsAdapter: IAdapter = {
@@ -13,9 +12,6 @@ export const datasetsAdapter: IAdapter = {
     id: openAIREResult.id,
     title: openAIREResult?.title?.join(' ') || '',
     description: openAIREResult?.description?.join(' ') || '',
-    date: openAIREResult['publication_date']
-      ? moment(openAIREResult['publication_date']).format('DD MMMM YYYY')
-      : '',
     url: `https://explore.eosc-portal.eu/search/result?id=${openAIREResult?.id
       ?.split('|')
       ?.pop()}`,
@@ -47,14 +43,14 @@ export const datasetsAdapter: IAdapter = {
         filter: 'author_names',
       },
       {
-        label: 'Field of science',
-        value: toArray(openAIREResult?.fos),
-        filter: 'fos',
-      },
-      {
         label: 'DOI',
         value: toArray(openAIREResult?.doi),
         filter: 'doi',
+      },
+      {
+        label: 'Field of Science',
+        value: toArray(openAIREResult?.fos),
+        filter: 'fos',
       },
     ],
     type: openAIREResult?.type || '',

--- a/ui/apps/ui/src/app/collections/data/publications/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/publications/adapter.data.ts
@@ -52,11 +52,6 @@ export const publicationsAdapter: IAdapter = {
         filter: 'publisher',
       },
       {
-        label: 'Field of science',
-        value: toArray(openAIREResult?.fos),
-        filter: 'fos',
-      },
-      {
         label: 'Document type',
         value: [...new Set(toArray(openAIREResult?.document_type))],
         filter: 'document_type',
@@ -65,6 +60,11 @@ export const publicationsAdapter: IAdapter = {
         label: 'DOI',
         value: toArray(openAIREResult?.doi),
         filter: 'doi',
+      },
+      {
+        label: 'Field of Science',
+        value: toArray(openAIREResult?.fos),
+        filter: 'fos',
       },
     ],
     type: openAIREResult?.type || '',

--- a/ui/apps/ui/src/app/collections/data/software/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/software/adapter.data.ts
@@ -2,7 +2,6 @@ import { IAdapter, IResult } from '../../repositories/types';
 import { IOpenAIREResult } from '../openair.model';
 import { COLLECTION } from './search-metadata.data';
 import { URL_PARAM_NAME } from './nav-config.data';
-import moment from 'moment';
 import { toArray } from '@collections/filters-serializers/utils';
 
 export const softwareAdapter: IAdapter = {
@@ -13,9 +12,6 @@ export const softwareAdapter: IAdapter = {
     id: openAIREResult.id,
     title: openAIREResult?.title?.join(' ') || '',
     description: openAIREResult?.description?.join(' ') || '',
-    date: openAIREResult['publication_date']
-      ? moment(openAIREResult['publication_date']).format('DD MMMM YYYY')
-      : '',
     url: `https://explore.eosc-portal.eu/search/result?id=${openAIREResult?.id
       ?.split('|')
       ?.pop()}`,
@@ -47,24 +43,14 @@ export const softwareAdapter: IAdapter = {
         filter: 'author_names',
       },
       {
-        label: 'Publisher',
-        value: toArray(openAIREResult?.publisher),
-        filter: 'publisher',
-      },
-      {
-        label: 'Field of science',
-        value: toArray(openAIREResult?.fos),
-        filter: 'fos',
-      },
-      {
-        label: 'Document type',
-        value: [...new Set(toArray(openAIREResult?.document_type))],
-        filter: 'document_type',
-      },
-      {
         label: 'DOI',
         value: toArray(openAIREResult?.doi),
         filter: 'doi',
+      },
+      {
+        label: 'Field of Science',
+        value: toArray(openAIREResult?.fos),
+        filter: 'fos',
       },
     ],
     type: openAIREResult?.type || '',

--- a/ui/apps/ui/src/app/collections/data/trainings/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/trainings/adapter.data.ts
@@ -20,11 +20,6 @@ export const trainingsAdapter: IAdapter = {
     url: '/trainings/' + training.id || '',
     coloredTags: [
       {
-        colorClassName: 'tag-almond',
-        value: toArray(training['license']),
-        filter: 'license',
-      },
-      {
         value: toArray(training?.best_access_right),
         filter: 'best_access_right',
         colorClassName: (training?.best_access_right || '').match(
@@ -32,6 +27,11 @@ export const trainingsAdapter: IAdapter = {
         )
           ? 'tag-light-green'
           : 'tag-light-coral',
+      },
+      {
+        colorClassName: 'tag-almond',
+        value: toArray(training['license']),
+        filter: 'license',
       },
       {
         colorClassName: 'tag-peach',


### PR DESCRIPTION
Issue: #220 

More details about implementation are covered in the issue comment:
https://github.com/cyfronet-fid/eosc-search-service/issues/220#issuecomment-1294795101

To filter resources containing certain fields in the catalog:
1. remove all filters
2. add `&fq=<field_name>:[* TO *]`

In our case:
- `publication_date`, `&fq=publication_date:[* TO *]`
Example: `https://eosc-search-service.grid.cyfronet.pl/search/training?q=*&fq=publication_date:[* TO *]`
- `fos`, `&fq=fos:[* TO *]`
Example: `https://eosc-search-service.grid.cyfronet.pl/search/publication?q=*&fq=fos:[* TO *]`
- `license`, `&fq=license:[* TO *]`
Example: `https://eosc-search-service.grid.cyfronet.pl/search/publication?q=*&fq=license:[* TO *]`

### !!!IMPORTANT!!!
Filters updates in `All catalog` is affected by a missing feature to show tags/date/colored tags in specific types of data.