### PR TITLE
chore: add configurable prefix to collections

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,3 +15,5 @@ STOMP_LOGIN: guest
 STOMP_PASS: guest
 STOMP_USER_ACTIONS_TOPIC: /topic/user_actions
 STOMP_CLIENT_NAME: dev-client
+
+NG_COLLECTIONS_PREFIX=

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Run `docker-compose up --build`.
 `npm i --force`
 
 ### Run
-**IMOPRTANT!!! To change collections prefix copy `<root>/.env` file to `<root>/ui` with proper env variable.**
+**IMOPRTANT!!! To change collections prefix copy `<root>/.env` file to `<root>/ui` with `NG_COLLECTIONS_PREFIX` env variable.**
 
 `npm start`
 
 ### Build
 Build artifacts can be found in `ui/dist/apps/ui`.
-**IMOPRTANT!!! To change collections prefix copy `<root>/.env` file to `<root>/ui` with proper env variable.**
+**IMOPRTANT!!! To change collections prefix copy `<root>/.env` file to `<root>/ui` with `NG_COLLECTIONS_PREFIX` env variable.**
 
 `npm build`
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Run `docker-compose up --build`.
 `npm i --force`
 
 ### Run
+**IMOPRTANT!!! To change collections prefix copy `<root>/.env` file to `<root>/ui` with proper env variable.**
+
 `npm start`
 
 ### Build
 Build artifacts can be found in `ui/dist/apps/ui`.
+**IMOPRTANT!!! To change collections prefix copy `<root>/.env` file to `<root>/ui` with proper env variable.**
 
 `npm build`
 
@@ -116,6 +119,9 @@ See docker-compose.yml for components.
   > Example: /topic/user_actions 
 - `STOMP_CLIENT_NAME`
   > Example: dev-client
+- `NG_COLLECTIONS_PREFIX`, by default `''`
+  > Example: NG_COLLECTIONS_PREFIX=prod_
+  > IMPORTANT!!! Before starting or building the app copy `.env` file to `<root>/ui` folder.
 
 `db` envs:
 - `DB_POSTGRES_DB`

--- a/ui/apps/ui/src/app/collections/data/all/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/search-metadata.data.ts
@@ -1,7 +1,8 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
+import { environment } from '@environment/environment';
 
-export const COLLECTION = 'all_collection';
+export const COLLECTION = environment.collectionsPrefix + 'all_collection';
 export const allCollectionsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: {

--- a/ui/apps/ui/src/app/collections/data/datasets/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/datasets/search-metadata.data.ts
@@ -1,7 +1,8 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
+import { environment } from '@environment/environment';
 
-export const COLLECTION = 'dataset';
+export const COLLECTION = environment.collectionsPrefix + 'dataset';
 export const datasetsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: {

--- a/ui/apps/ui/src/app/collections/data/publications/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/publications/search-metadata.data.ts
@@ -1,7 +1,8 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
+import { environment } from '@environment/environment';
 
-export const COLLECTION = 'publication';
+export const COLLECTION = environment.collectionsPrefix + 'publication';
 export const publicationsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: {

--- a/ui/apps/ui/src/app/collections/data/services/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/services/search-metadata.data.ts
@@ -1,7 +1,8 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
+import { environment } from '@environment/environment';
 
-export const COLLECTION = 'service';
+export const COLLECTION = environment.collectionsPrefix + 'service';
 export const servicesSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: {

--- a/ui/apps/ui/src/app/collections/data/software/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/software/search-metadata.data.ts
@@ -1,7 +1,8 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
+import { environment } from '@environment/environment';
 
-export const COLLECTION = 'software';
+export const COLLECTION = environment.collectionsPrefix + 'software';
 export const softwareSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: {

--- a/ui/apps/ui/src/app/collections/data/trainings/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/trainings/search-metadata.data.ts
@@ -1,7 +1,8 @@
 import { URL_PARAM_NAME } from './nav-config.data';
 import { ICollectionSearchMetadata } from '../../repositories/types';
+import { environment } from '@environment/environment';
 
-export const COLLECTION = 'training';
+export const COLLECTION = environment.collectionsPrefix + 'training';
 export const trainingsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: {

--- a/ui/apps/ui/src/environments/environment.common.ts
+++ b/ui/apps/ui/src/environments/environment.common.ts
@@ -9,6 +9,7 @@ import { sharedEnvironment } from './environment.generated';
 
 export const commonEnvironment = {
   // @ts-ignore
+  collectionsPrefix: '',
   ...sharedEnvironment,
   backendApiPath: 'api/web',
   navigationApiPath: 'navigate',


### PR DESCRIPTION
- add prefixes to collections, by default `NG_COLLECTIONS_PREFIX=''`

Building pipe updates for @wziajka 
- [ ] add the new environment variable to the .env file in the format: `NG_COLLECTIONS_PREFIX=<collection_prefix>`
Example: `NG_COLLECTIONS_PREFIX=prod_` for `production`
- [ ] before building the UI package, copy the `.env` file to the `<root>/ui` catalog

closes #307