### PR TITLE
chore: remove requirement for facets in multiselect configuration

### DIFF
--- a/ui/apps/ui/src/app/collections/data/all/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/search-metadata.data.ts
@@ -7,7 +7,6 @@ export const COLLECTION = environment.collectionsPrefix + 'all_collection';
 export const allCollectionsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: DEFAULT_FACET,
-  queryMutator: (q: string) => q,
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],
     collection: COLLECTION,

--- a/ui/apps/ui/src/app/collections/data/all/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/search-metadata.data.ts
@@ -1,21 +1,12 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
 import { environment } from '@environment/environment';
+import { DEFAULT_FACET } from '@collections/data/config';
 
 export const COLLECTION = environment.collectionsPrefix + 'all_collection';
 export const allCollectionsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
-  facets: {
-    type: { field: 'type', type: 'terms', limit: 0 },
-    best_access_right: { field: 'best_access_right', type: 'terms', limit: 0 },
-    language: { field: 'language', type: 'terms', limit: 0 },
-    fos: { field: 'fos', type: 'terms', limit: 0 },
-    unified_categories: {
-      field: 'unified_categories',
-      type: 'terms',
-      limit: 0,
-    },
-  },
+  facets: DEFAULT_FACET,
   queryMutator: (q: string) => q,
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],

--- a/ui/apps/ui/src/app/collections/data/config.ts
+++ b/ui/apps/ui/src/app/collections/data/config.ts
@@ -1,0 +1,5 @@
+import { IFacetParam } from '@collections/repositories/types';
+
+export const DEFAULT_FACET: { [field: string]: IFacetParam } = {
+  title: { field: 'title', type: 'terms', limit: 0 },
+};

--- a/ui/apps/ui/src/app/collections/data/data-sources/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/data-sources/search-metadata.data.ts
@@ -7,7 +7,6 @@ export const COLLECTION = environment.collectionsPrefix + 'data_source';
 export const dataSourcesSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: DEFAULT_FACET,
-  queryMutator: (q: string) => q + '*',
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],
     collection: COLLECTION,

--- a/ui/apps/ui/src/app/collections/data/data-sources/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/data-sources/search-metadata.data.ts
@@ -1,57 +1,12 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
 import { environment } from '@environment/environment';
+import { DEFAULT_FACET } from '@collections/data/config';
 
 export const COLLECTION = environment.collectionsPrefix + 'data_source';
 export const dataSourcesSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
-  facets: {
-    scientific_domains: {
-      field: 'scientific_domains',
-      type: 'terms',
-      limit: 0,
-    },
-    providers: {
-      field: 'providers',
-      type: 'terms',
-      limit: 0,
-    },
-    dedicated_for: {
-      field: 'dedicated_for',
-      type: 'terms',
-      limit: 0,
-    },
-    related_platforms: {
-      field: 'related_platforms',
-      type: 'terms',
-      limit: 0,
-    },
-    rating: {
-      field: 'rating',
-      type: 'terms',
-      limit: 0,
-    },
-    geographical_availabilities: {
-      field: 'geographical_availabilities',
-      type: 'terms',
-      limit: 0,
-    },
-    categories: {
-      field: 'categories',
-      type: 'terms',
-      limit: 0,
-    },
-    resource_organisation: {
-      field: 'resource_organisation',
-      type: 'terms',
-      limit: 0,
-    },
-    best_access_right: {
-      field: 'best_access_right',
-      type: 'terms',
-      limit: 0,
-    },
-  },
+  facets: DEFAULT_FACET,
   queryMutator: (q: string) => q + '*',
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],

--- a/ui/apps/ui/src/app/collections/data/datasets/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/datasets/search-metadata.data.ts
@@ -1,26 +1,12 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
 import { environment } from '@environment/environment';
+import { DEFAULT_FACET } from '@collections/data/config';
 
 export const COLLECTION = environment.collectionsPrefix + 'dataset';
 export const datasetsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
-  facets: {
-    document_type: { field: 'document_type', type: 'terms', limit: 0 },
-    best_access_right: { field: 'best_access_right', type: 'terms', limit: 0 },
-    language: { field: 'language', type: 'terms', limit: 0 },
-    fos: { field: 'fos', type: 'terms', limit: 0 },
-    publisher: { field: 'publisher', type: 'terms', limit: 0 },
-    funder: { field: 'funder', type: 'terms', limit: 0 },
-    sdg: { field: 'sdg', type: 'terms', limit: 0 },
-    country: { field: 'country', type: 'terms', limit: 0 },
-    source: { field: 'source', type: 'terms', limit: 0 },
-    research_community: {
-      field: 'research_community',
-      type: 'terms',
-      limit: 0,
-    },
-  },
+  facets: DEFAULT_FACET,
   queryMutator: (q: string) => q,
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],

--- a/ui/apps/ui/src/app/collections/data/datasets/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/datasets/search-metadata.data.ts
@@ -7,7 +7,6 @@ export const COLLECTION = environment.collectionsPrefix + 'dataset';
 export const datasetsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: DEFAULT_FACET,
-  queryMutator: (q: string) => q,
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],
     collection: COLLECTION,

--- a/ui/apps/ui/src/app/collections/data/publications/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/publications/search-metadata.data.ts
@@ -7,7 +7,6 @@ export const COLLECTION = environment.collectionsPrefix + 'publication';
 export const publicationsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: DEFAULT_FACET,
-  queryMutator: (q: string) => q,
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],
     collection: COLLECTION,

--- a/ui/apps/ui/src/app/collections/data/publications/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/publications/search-metadata.data.ts
@@ -1,26 +1,12 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
 import { environment } from '@environment/environment';
+import { DEFAULT_FACET } from '@collections/data/config';
 
 export const COLLECTION = environment.collectionsPrefix + 'publication';
 export const publicationsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
-  facets: {
-    document_type: { field: 'document_type', type: 'terms', limit: 0 },
-    best_access_right: { field: 'best_access_right', type: 'terms', limit: 0 },
-    language: { field: 'language', type: 'terms', limit: 0 },
-    fos: { field: 'fos', type: 'terms', limit: 0 },
-    publisher: { field: 'publisher', type: 'terms', limit: 0 },
-    funder: { field: 'funder', type: 'terms', limit: 0 },
-    sdg: { field: 'sdg', type: 'terms', limit: 0 },
-    country: { field: 'country', type: 'terms', limit: 0 },
-    source: { field: 'source', type: 'terms', limit: 0 },
-    research_community: {
-      field: 'research_community',
-      type: 'terms',
-      limit: 0,
-    },
-  },
+  facets: DEFAULT_FACET,
   queryMutator: (q: string) => q,
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],

--- a/ui/apps/ui/src/app/collections/data/services/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/services/search-metadata.data.ts
@@ -7,7 +7,6 @@ export const COLLECTION = environment.collectionsPrefix + 'service';
 export const servicesSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: DEFAULT_FACET,
-  queryMutator: (q: string) => q + '*',
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],
     collection: COLLECTION,

--- a/ui/apps/ui/src/app/collections/data/services/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/services/search-metadata.data.ts
@@ -1,57 +1,12 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
 import { environment } from '@environment/environment';
+import { DEFAULT_FACET } from '@collections/data/config';
 
 export const COLLECTION = environment.collectionsPrefix + 'service';
 export const servicesSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
-  facets: {
-    scientific_domains: {
-      field: 'scientific_domains',
-      type: 'terms',
-      limit: 0,
-    },
-    providers: {
-      field: 'providers',
-      type: 'terms',
-      limit: 0,
-    },
-    dedicated_for: {
-      field: 'dedicated_for',
-      type: 'terms',
-      limit: 0,
-    },
-    related_platforms: {
-      field: 'related_platforms',
-      type: 'terms',
-      limit: 0,
-    },
-    rating: {
-      field: 'rating',
-      type: 'terms',
-      limit: 0,
-    },
-    geographical_availabilities: {
-      field: 'geographical_availabilities',
-      type: 'terms',
-      limit: 0,
-    },
-    categories: {
-      field: 'categories',
-      type: 'terms',
-      limit: 0,
-    },
-    resource_organisation: {
-      field: 'resource_organisation',
-      type: 'terms',
-      limit: 0,
-    },
-    best_access_right: {
-      field: 'best_access_right',
-      type: 'terms',
-      limit: 0,
-    },
-  },
+  facets: DEFAULT_FACET,
   queryMutator: (q: string) => q + '*',
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],

--- a/ui/apps/ui/src/app/collections/data/software/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/software/search-metadata.data.ts
@@ -1,26 +1,12 @@
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
 import { environment } from '@environment/environment';
+import { DEFAULT_FACET } from '@collections/data/config';
 
 export const COLLECTION = environment.collectionsPrefix + 'software';
 export const softwareSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
-  facets: {
-    document_type: { field: 'document_type', type: 'terms', limit: 0 },
-    best_access_right: { field: 'best_access_right', type: 'terms', limit: 0 },
-    language: { field: 'language', type: 'terms', limit: 0 },
-    fos: { field: 'fos', type: 'terms', limit: 0 },
-    publisher: { field: 'publisher', type: 'terms', limit: 0 },
-    funder: { field: 'funder', type: 'terms', limit: 0 },
-    sdg: { field: 'sdg', type: 'terms', limit: 0 },
-    country: { field: 'country', type: 'terms', limit: 0 },
-    source: { field: 'source', type: 'terms', limit: 0 },
-    research_community: {
-      field: 'research_community',
-      type: 'terms',
-      limit: 0,
-    },
-  },
+  facets: DEFAULT_FACET,
   queryMutator: (q: string) => q,
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],

--- a/ui/apps/ui/src/app/collections/data/software/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/software/search-metadata.data.ts
@@ -7,7 +7,6 @@ export const COLLECTION = environment.collectionsPrefix + 'software';
 export const softwareSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: DEFAULT_FACET,
-  queryMutator: (q: string) => q,
   params: {
     qf: ['title^50', 'author_names^30', 'description^10'],
     collection: COLLECTION,

--- a/ui/apps/ui/src/app/collections/data/trainings/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/trainings/search-metadata.data.ts
@@ -1,31 +1,12 @@
 import { URL_PARAM_NAME } from './nav-config.data';
 import { ICollectionSearchMetadata } from '../../repositories/types';
 import { environment } from '@environment/environment';
+import { DEFAULT_FACET } from '@collections/data/config';
 
 export const COLLECTION = environment.collectionsPrefix + 'training';
 export const trainingsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
-  facets: {
-    resource_type: { field: 'resource_type', type: 'terms', limit: 0 },
-    content_type: { field: 'content_type', type: 'terms', limit: 0 },
-    language: { field: 'language', type: 'terms', limit: 0 },
-    eosc_provider: { field: 'eosc_provider', type: 'terms', limit: 0 },
-    format: { field: 'format', type: 'terms', limit: 0 },
-    level_of_expertise: {
-      field: 'level_of_expertise',
-      type: 'terms',
-      limit: 0,
-    },
-    target_group: { field: 'target_group', type: 'terms', limit: 0 },
-    qualification: { field: 'qualification', type: 'terms', limit: 0 },
-    duration: { field: 'duration', type: 'terms', limit: 0 },
-    publication_date: {
-      field: 'publication_date',
-      type: 'terms',
-      limit: 0,
-    },
-    best_access_right: { field: 'best_access_right', type: 'terms', limit: 0 },
-  },
+  facets: DEFAULT_FACET,
   queryMutator: (q: string) => q,
   params: {
     qf: ['title', 'description', 'keywords'],

--- a/ui/apps/ui/src/app/collections/data/trainings/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/trainings/search-metadata.data.ts
@@ -7,7 +7,6 @@ export const COLLECTION = environment.collectionsPrefix + 'training';
 export const trainingsSearchMetadata: ICollectionSearchMetadata = {
   id: URL_PARAM_NAME,
   facets: DEFAULT_FACET,
-  queryMutator: (q: string) => q,
   params: {
     qf: ['title', 'description', 'keywords'],
     collection: COLLECTION,

--- a/ui/apps/ui/src/app/collections/data/validators.ts
+++ b/ui/apps/ui/src/app/collections/data/validators.ts
@@ -106,12 +106,11 @@ export const _validateFiltersConsistency = (
   filters: IFiltersConfig[],
   adapters: IAdapter[]
 ): void => {
-  searchMetadata.forEach(({ id: metadataId, facets }) => {
+  searchMetadata.forEach(({ id: metadataId }) => {
     const collectionFilters = filters.find(
       ({ id: filterId }) => filterId === metadataId
     ) as IFiltersConfig;
     const filtersNames = collectionFilters.filters.map(({ filter }) => filter);
-    const facetsNames = Object.keys(facets);
 
     const adapter = adapters.find(
       ({ id: adapterId }) => metadataId === adapterId
@@ -131,20 +130,6 @@ export const _validateFiltersConsistency = (
     if (missingFilters.length > 0) {
       throw Error(
         `[COLLECTIONS VALIDATOR]: Missing adapter tags filters configurations: ${missingFilters}, for: ${metadataId}`
-      );
-    }
-
-    const sideNavFiltersNames = collectionFilters.filters
-      .filter(({ type }) => type === 'multiselect')
-      .map(({ filter }) => filter);
-    const missingFacets = differenceWith(
-      sideNavFiltersNames,
-      facetsNames,
-      isEqual
-    );
-    if (missingFacets.length > 0) {
-      throw Error(
-        `[COLLECTIONS VALIDATOR]: Missing search metadata facets for filters configurations: ${missingFacets}, for: "${metadataId}"`
       );
     }
   });

--- a/ui/apps/ui/src/app/collections/repositories/types.ts
+++ b/ui/apps/ui/src/app/collections/repositories/types.ts
@@ -92,7 +92,6 @@ export interface IFilterConfig {
 export interface ICollectionSearchMetadata {
   id: string;
   facets: { [field: string]: IFacetParam };
-  queryMutator: (q: string) => string;
   params: ISolrCollectionParams;
 }
 

--- a/ui/apps/ui/src/app/components/filters/filter-multiselect/filter-multiselect.service.ts
+++ b/ui/apps/ui/src/app/components/filters/filter-multiselect/filter-multiselect.service.ts
@@ -60,7 +60,7 @@ export class FilterMultiselectService {
     return this._fetchTreeNodes$(
       filter,
       toSearchMetadata('*', [], metadata),
-      toFilterFacet(filter, metadata.facets)
+      toFilterFacet(filter)
     ).pipe(
       map(
         (entities) =>
@@ -85,7 +85,7 @@ export class FilterMultiselectService {
     return this._fetchTreeNodes$(
       filter,
       toSearchMetadata(q, fq, metadata),
-      toFilterFacet(filter, metadata.facets)
+      toFilterFacet(filter)
     ).pipe(map((entities) => entities.map(({ id, count }) => ({ id, count }))));
   }
   private _fetchTreeNodes$(

--- a/ui/apps/ui/src/app/components/filters/filter-multiselect/utils.ts
+++ b/ui/apps/ui/src/app/components/filters/filter-multiselect/utils.ts
@@ -22,11 +22,11 @@ export const toSearchMetadata = (
 });
 
 export const toFilterFacet = (
-  filter: string,
-  facets: { [facet: string]: IFacetParam }
-) => ({
+  filter: string
+): { [field: string]: IFacetParam } => ({
   [filter]: {
-    ...facets[filter],
+    field: filter,
+    type: 'terms',
     limit: -1,
   },
 });

--- a/ui/apps/ui/src/app/components/filters/filter-multiselect/utils.ts
+++ b/ui/apps/ui/src/app/components/filters/filter-multiselect/utils.ts
@@ -13,7 +13,7 @@ export const toSearchMetadata = (
   fq: string[],
   metadata: ICollectionSearchMetadata
 ) => ({
-  q: metadata.queryMutator(q),
+  q: q,
   fq,
   cursor: '*',
   rows: 0,

--- a/ui/apps/ui/src/app/pages/search-page/search-page.component.ts
+++ b/ui/apps/ui/src/app/pages/search-page/search-page.component.ts
@@ -108,7 +108,7 @@ export class SearchPageComponent implements OnInit {
             rows: MAX_COLLECTION_RESULTS,
             ...routerParams,
             ...metadata.params,
-            q: metadata.queryMutator(routerParams.q),
+            q: routerParams.q,
           };
           return this._fetchDataService.fetchResults$(
             searchMetadata,


### PR DESCRIPTION
- move generating configuration from the top level to multi-select component
- resolve the app's critical error, when some multi-select filter doesn't exist in SOLR