### PR TITLE
[#241] Fix pagination bug on every 5th page

### DIFF
--- a/ui/apps/ui/src/app/components/results-with-pagination/pagination.service.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/pagination.service.ts
@@ -16,12 +16,17 @@ export class PaginationService {
 
   initPagination = (response: ISearchResults<IResult>) =>
     this._paginationRepository.initialize(response);
+
   updatePagination = (
     allUrlParams: { [name: string]: paramType },
-    response: ISearchResults<IResult>
+    response: ISearchResults<IResult>,
+    newPageNr: number
   ) => {
     this._paginationRepository.addResultsAndPaginate(response.results);
     this._paginationRepository.setNextCursor(response.nextCursorMark);
+    this._paginationRepository.updatePaginationData({
+      currentPage: newPageNr,
+    });
   };
 
   hasPage = (pageNr: number) => {

--- a/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.ts
@@ -95,7 +95,11 @@ export class ResultsWithPaginationComponent implements OnInit {
       return;
     }
 
-    this._paginationService.updatePagination(params, response);
+    this._paginationService.updatePagination(
+      params,
+      response,
+      this.pageNr$.value
+    );
     this.highlights = response.highlighting ?? {};
 
     this._paginationService.setLoading(false);


### PR DESCRIPTION
The issue was that the currentPage was not set after additional results were fetched (which happens on every 5th page, due to set constants).

Due to invalid page setting when fetching new results, this also caused the paginaton to be broken and in some cases one page would be overwritten and results were lost the user (!) - fixed that as well.

Closes #241