### PR TITLE
fix: [#283] Range does not disappear with other filters

### DIFF
--- a/ui/apps/ui/src/app/collections/filters-serializers/filters-serializers.utils.ts
+++ b/ui/apps/ui/src/app/collections/filters-serializers/filters-serializers.utils.ts
@@ -97,7 +97,7 @@ export const deserialize = (
     case 'range':
       return new RangeDeserializer()
         .filter(filter)
-        .values(values as [number, number])
+        .values(values as [number, number] | string)
         .deserialize();
     case 'date':
       return new DateDeserializer()


### PR DESCRIPTION
Deserialization assumed that the input will be of [number, number] type. This is not the case when the string was serialized to `00:00:00 TO HH:MM:SS` format. 

Changed the deserialization so that it can take the second format as well.

Closes #283 