### PR TITLE
fix: [#524] User is redirected to the top of the page after pagination

### DIFF
--- a/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.ts
@@ -126,7 +126,12 @@ export class ResultsWithPaginationComponent implements OnInit {
       .pipe(
         untilDestroyed(this),
         skip(1),
-        tap((pageNr) => this._loadNewPage(pageNr))
+        tap((pageNr) => {
+          setTimeout(() => {
+            window.scrollTo(0, 0);
+          }, 100);
+          this._loadNewPage(pageNr);
+        })
       )
       .subscribe();
   }


### PR DESCRIPTION
User is now redirected to the top after chaging the page.

Closes #524 