### PR TITLE
feat: Add configurable explore url

### DIFF
--- a/.github/workflows/backend-styles.yml
+++ b/.github/workflows/backend-styles.yml
@@ -19,6 +19,7 @@ jobs:
       working-directory: ./backend
     - name: Check with black
       run: |
+        pipenv run black --version
         pipenv run black --check --preview alembic app tests
       working-directory: ./backend
     - name: Check with isort

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ See docker-compose.yml for components.
   > Default: `production`
   > Together with `EOSC_COMMONS_URL` two assets are loaded:
   > `<EOSC_COMMONS_URL>index.<EOSC_COMMONS_ENV>.min.js` and `<EOSC_COMMONS_URL>index.<EOSC_COMMONS_ENV>.min.css`
+- `EOSC_EXPLORE_URL`
+  > base url to explore - used when constructing links for publications
+  > Use when integrating with explore beta instance
+  > Default: https://explore.eosc-portal.eu
 
 `db` envs:
 - `DB_POSTGRES_DB`

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -165,3 +165,6 @@ EOSC_COMMONS_URL = config(
 )
 
 EOSC_COMMONS_ENV = config("EOSC_COMMONS_ENV", cast=str, default="production")
+EOSC_EXPLORE_URL = config(
+    "EOSC_EXPLORE_URL", cast=str, default="https://explore.eosc-portal.eu"
+)

--- a/backend/app/routes/web/configuration.py
+++ b/backend/app/routes/web/configuration.py
@@ -3,7 +3,12 @@
 
 from fastapi import APIRouter
 
-from app.config import EOSC_COMMONS_ENV, EOSC_COMMONS_URL, MARKETPLACE_BASE_URL
+from app.config import (
+    EOSC_COMMONS_ENV,
+    EOSC_COMMONS_URL,
+    EOSC_EXPLORE_URL,
+    MARKETPLACE_BASE_URL,
+)
 from app.schemas.configuration_response import ConfigurationResponse
 
 router = APIRouter()
@@ -13,6 +18,7 @@ router = APIRouter()
 async def config():
     return ConfigurationResponse(
         marketplace_url=MARKETPLACE_BASE_URL,
+        eosc_explore_url=EOSC_EXPLORE_URL,
         eosc_commons_url=EOSC_COMMONS_URL,
         eosc_commons_env=EOSC_COMMONS_ENV,
     )

--- a/backend/app/schemas/configuration_response.py
+++ b/backend/app/schemas/configuration_response.py
@@ -6,3 +6,4 @@ class ConfigurationResponse(BaseModel):
     marketplace_url: AnyHttpUrl
     eosc_commons_url: AnyHttpUrl
     eosc_commons_env: str
+    eosc_explore_url: AnyHttpUrl

--- a/backend/tests/app/routes/test_configuration.py
+++ b/backend/tests/app/routes/test_configuration.py
@@ -6,7 +6,7 @@ from starlette.status import HTTP_200_OK
 
 
 @pytest.mark.asyncio
-async def test_passes_all_facets(app: FastAPI, client: AsyncClient) -> None:
+async def test_return_backend_config(app: FastAPI, client: AsyncClient) -> None:
     response = await client.get(app.url_path_for("web:configuration"))
 
     assert response.status_code == HTTP_200_OK
@@ -14,4 +14,5 @@ async def test_passes_all_facets(app: FastAPI, client: AsyncClient) -> None:
         "eosc_commons_env": "production",
         "eosc_commons_url": "https://s3.cloud.cyfronet.pl/eosc-portal-common/",
         "marketplace_url": "https://marketplace.eosc-portal.eu",
+        "eosc_explore_url": "https://explore.eosc-portal.eu",
     }

--- a/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
@@ -34,9 +34,9 @@ const urlAdapter = (
     case 'publication':
     case 'software':
     case 'other':
-      return `https://explore.eosc-portal.eu/search/result?id=${data?.id
-        ?.split('|')
-        ?.pop()}`;
+      return `${
+        ConfigService.config?.eosc_explore_url
+      }/search/result?id=${data?.id?.split('|')?.pop()}`;
     case 'data source':
       return hackDataSourceUrl(data?.pid);
     case 'service':

--- a/ui/apps/ui/src/app/collections/data/datasets/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/datasets/adapter.data.ts
@@ -14,6 +14,7 @@ import {
   parseStatistics,
   toKeywordsSecondaryTag,
 } from '@collections/data/utils';
+import { ConfigService } from '../../../services/config.service';
 
 export const datasetsAdapter: IAdapter = {
   id: URL_PARAM_NAME,
@@ -23,9 +24,9 @@ export const datasetsAdapter: IAdapter = {
     id: openAIREResult.id,
     title: openAIREResult?.title?.join(' ') || '',
     description: openAIREResult?.description?.join(' ') || '',
-    url: `https://explore.eosc-portal.eu/search/result?id=${openAIREResult?.id
-      ?.split('|')
-      ?.pop()}`,
+    url: `${
+      ConfigService.config?.eosc_explore_url
+    }/search/result?id=${openAIREResult?.id?.split('|')?.pop()}`,
     coloredTags: [
       toAccessRightColoredTag(openAIREResult?.best_access_right),
       {

--- a/ui/apps/ui/src/app/collections/data/other-resources-products/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/other-resources-products/adapter.data.ts
@@ -10,6 +10,7 @@ import {
   parseStatistics,
   toKeywordsSecondaryTag,
 } from '@collections/data/utils';
+import { ConfigService } from '../../../services/config.service';
 
 export const otherResourcesProductsAdapter: IAdapter = {
   id: URL_PARAM_NAME,
@@ -19,9 +20,9 @@ export const otherResourcesProductsAdapter: IAdapter = {
     id: openAIREResult.id,
     title: openAIREResult?.title?.join(' ') || '',
     description: openAIREResult?.description?.join(' ') || '',
-    url: `https://explore.eosc-portal.eu/search/result?id=${openAIREResult?.id
-      ?.split('|')
-      ?.pop()}`,
+    url: `${
+      ConfigService.config?.eosc_explore_url
+    }/search/result?id=${openAIREResult?.id?.split('|')?.pop()}`,
     coloredTags: [
       {
         values: toValueWithLabel(toArray(openAIREResult?.best_access_right)),

--- a/ui/apps/ui/src/app/collections/data/publications/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/publications/adapter.data.ts
@@ -15,6 +15,7 @@ import {
   parseStatistics,
   toKeywordsSecondaryTag,
 } from '@collections/data/utils';
+import { ConfigService } from '../../../services/config.service';
 
 export const publicationsAdapter: IAdapter = {
   id: URL_PARAM_NAME,
@@ -27,9 +28,9 @@ export const publicationsAdapter: IAdapter = {
     date: openAIREResult['publication_date']
       ? moment(openAIREResult['publication_date']).format('DD MMMM YYYY')
       : '',
-    url: `https://explore.eosc-portal.eu/search/result?id=${openAIREResult?.id
-      ?.split('|')
-      ?.pop()}`,
+    url: `${
+      ConfigService.config?.eosc_explore_url
+    }/search/result?id=${openAIREResult?.id?.split('|')?.pop()}`,
     coloredTags: [
       toAccessRightColoredTag(openAIREResult?.best_access_right),
       {

--- a/ui/apps/ui/src/app/collections/data/software/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/software/adapter.data.ts
@@ -14,6 +14,7 @@ import {
   parseStatistics,
   toKeywordsSecondaryTag,
 } from '@collections/data/utils';
+import { ConfigService } from '../../../services/config.service';
 
 export const softwareAdapter: IAdapter = {
   id: URL_PARAM_NAME,
@@ -23,9 +24,9 @@ export const softwareAdapter: IAdapter = {
     id: openAIREResult.id,
     title: openAIREResult?.title?.join(' ') || '',
     description: openAIREResult?.description?.join(' ') || '',
-    url: `https://explore.eosc-portal.eu/search/result?id=${openAIREResult?.id
-      ?.split('|')
-      ?.pop()}`,
+    url: `${
+      ConfigService.config?.eosc_explore_url
+    }/search/result?id=${openAIREResult?.id?.split('|')?.pop()}`,
     coloredTags: [
       toAccessRightColoredTag(openAIREResult?.best_access_right),
       {

--- a/ui/apps/ui/src/app/collections/services/redirect.service.ts
+++ b/ui/apps/ui/src/app/collections/services/redirect.service.ts
@@ -22,11 +22,13 @@ export class RedirectService {
     const sourceUrl = this._router.url.includes('?')
       ? `${this._router.url}&url=${encodeURIComponent(externalUrl)}`
       : `${this._router.url}?url=${encodeURIComponent(externalUrl)}`;
-    const sourceQueryParams =
-      sourceUrl.split('?')[1] + `&pv=search/${this._customRoute.collection()}`;
+    const encodedPv = encodeURIComponent(
+      'search/' + this._customRoute.collection()
+    );
+    const sourceQueryParams = sourceUrl.split('?')[1] + `&pv=${encodedPv}`;
 
     const destinationUrl = `${environment.backendApiPath}/${environment.navigationApiPath}`;
     const destinationQueryParams = `${sourceQueryParams}&collection=${this._customRoute.collection()}`;
-    return `${destinationUrl}?${destinationQueryParams}&resource_id=${id}&resource_type=${type}&page_id=/search/${this._customRoute.collection()}&recommendation=${recommendation}`;
+    return `${destinationUrl}?${destinationQueryParams}&resource_id=${id}&resource_type=${type}&page_id=${encodedPv}&recommendation=${recommendation}`;
   }
 }

--- a/ui/apps/ui/src/app/services/config.service.ts
+++ b/ui/apps/ui/src/app/services/config.service.ts
@@ -10,6 +10,7 @@ export interface BackendConfig {
   marketplace_url: string;
   eosc_commons_url: string;
   eosc_commons_env: string;
+  eosc_explore_url: string;
 }
 
 @Injectable({


### PR DESCRIPTION
@wziajka should set `EOSC_EXPLORE_URL` env variable to explore beta: `https://beta.explore.eosc-portal.eu` (on the backend API container)

* Add configurable explore url 
* Url encode pv parameter