### PR TITLE
fix: [#169] Tighten fuzzy search in filter search

### DIFF
--- a/ui/apps/ui/src/app/components/filters/filter-multiselect/utils.ts
+++ b/ui/apps/ui/src/app/components/filters/filter-multiselect/utils.ts
@@ -22,6 +22,7 @@ export const search = (query: string | null, entities: IFilterNode[]) => {
   return new Fuse(entities, {
     keys: ['name'],
     shouldSort: false,
+    threshold: 0.2,
   })
     .search(query)
     .map(({ item }) => item);


### PR DESCRIPTION
Closes #169 

Well, I'm not really sure what is meant by "improve" in the issue ticket, I noticed, however, that the results were sometimes really far away from the actual search query so I've raised the default threshold for the fuzzy search options - so now results should be much stricter in terms of search query (TLDR: less random results) 

More info: https://www.fusejs.io/api/options.html#threshold