### PR TITLE
fix: [#752] fix sort by rel beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ See docker-compose.yml for components.
   > Default: https://explore.eosc-portal.eu
 - `RELATED_SERVICES_ENDPOINT`
   > base url to get related services for interoperability guidelines. Default: https://beta.providers.eosc-portal.eu/api/public/interoperabilityRecord/relatedResources
+- `IS_SORT_BY_RELEVANCE`
+  > Boolean variable that indicates whether sort by relevance should be enabled on the instance level. Default: False.
+
 
 `db` envs:
 - `DB_POSTGRES_DB`

--- a/backend/app/routes/web/configuration.py
+++ b/backend/app/routes/web/configuration.py
@@ -16,4 +16,5 @@ async def config():
         eosc_explore_url=settings.EOSC_EXPLORE_URL,
         eosc_commons_url=settings.EOSC_COMMONS_URL,
         eosc_commons_env=settings.EOSC_COMMONS_ENV,
+        is_sort_by_relevance=settings.IS_SORT_BY_RELEVANCE,
     )

--- a/backend/app/schemas/configuration_response.py
+++ b/backend/app/schemas/configuration_response.py
@@ -7,3 +7,4 @@ class ConfigurationResponse(BaseModel):
     eosc_commons_url: AnyHttpUrl
     eosc_commons_env: str
     eosc_explore_url: AnyHttpUrl
+    is_sort_by_relevance: bool

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -60,6 +60,7 @@ class GlobalSettings(BaseSettings):
     EOSC_COMMONS_ENV: str = "production"
     EOSC_EXPLORE_URL: AnyUrl = "https://explore.eosc-portal.eu"
     RELATED_SERVICES_ENDPOINT: AnyUrl = "https://beta.providers.eosc-portal.eu/api/public/interoperabilityRecord/relatedResources"
+    IS_SORT_BY_RELEVANCE: bool = False
 
     @root_validator()
     def oidc_issuer_path(cls, values):

--- a/backend/tests/app/routes/test_configuration.py
+++ b/backend/tests/app/routes/test_configuration.py
@@ -15,4 +15,5 @@ async def test_return_backend_config(app: FastAPI, client: AsyncClient) -> None:
         "eosc_commons_url": "https://s3.cloud.cyfronet.pl/eosc-portal-common/",
         "marketplace_url": "https://marketplace.eosc-portal.eu",
         "eosc_explore_url": "https://explore.eosc-portal.eu",
+        "is_sort_by_relevance": False,
     }

--- a/ui/apps/ui/src/app/collections/data/providers/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/providers/adapter.data.ts
@@ -17,6 +17,7 @@ const getDescription = (desc: string[]) => {
 export const providersAdapter: IAdapter = {
   id: URL_PARAM_NAME,
   adapter: (provider: Partial<IProvider> & { id: string }): IResult => ({
+    isSortByRelevanceCollectionScopeOff: true,
     id: uuidv4(),
     title: provider['title'] ? provider['title'].toString() : '',
     abbreviation: provider['abbreviation']

--- a/ui/apps/ui/src/app/components/recommendations/recommendations.component.ts
+++ b/ui/apps/ui/src/app/components/recommendations/recommendations.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { RedirectService } from '@collections/services/redirect.service';
 import { RecommendationsService } from '@components/recommendations/recommendations.service';
-import { of, pipe, switchMap } from 'rxjs';
+import { of, switchMap } from 'rxjs';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { CustomRoute } from '@collections/services/custom-route.service';
 import { IResult } from '@collections/repositories/types';

--- a/ui/apps/ui/src/app/components/sort-by-functionality/sort-by-functionality.component.ts
+++ b/ui/apps/ui/src/app/components/sort-by-functionality/sort-by-functionality.component.ts
@@ -10,7 +10,7 @@ import {
   isSortOption,
   sortType,
 } from '@components/sort-by-functionality/sort-value.type';
-import { environment } from '@environment/environment';
+import { ConfigService } from '../../services/config.service';
 
 @UntilDestroy()
 @Component({
@@ -77,7 +77,9 @@ import { environment } from '@environment/environment';
   ],
 })
 export class SortByFunctionalityComponent implements OnInit {
-  isSortByRelevanceInstanceScope: boolean = environment.isSortByRelevance;
+  isSortByRelevanceInstanceScope: boolean =
+    ConfigService.config?.is_sort_by_relevance;
+
   @Input()
   isSortByRelevanceCollectionScopeOff!: boolean;
 

--- a/ui/apps/ui/src/app/pages/search-page/search-page.component.ts
+++ b/ui/apps/ui/src/app/pages/search-page/search-page.component.ts
@@ -11,10 +11,7 @@ import {
   ISearchResults,
   adapterType,
 } from '@collections/repositories/types';
-import {
-  MAX_COLLECTION_RESULTS,
-  PaginationRepository,
-} from '@components/results-with-pagination/pagination.repository';
+import { MAX_COLLECTION_RESULTS } from '@components/results-with-pagination/pagination.repository';
 import { ActivatedRoute, Router } from '@angular/router';
 import { combineLatest } from 'rxjs';
 import { queryChanger } from '@collections/filters-serializers/utils';

--- a/ui/apps/ui/src/app/services/config.service.ts
+++ b/ui/apps/ui/src/app/services/config.service.ts
@@ -11,6 +11,7 @@ export interface BackendConfig {
   eosc_commons_url: string;
   eosc_commons_env: string;
   eosc_explore_url: string;
+  is_sort_by_relevance: boolean;
 }
 
 @Injectable({

--- a/ui/apps/ui/src/environments/environment.common.ts
+++ b/ui/apps/ui/src/environments/environment.common.ts
@@ -2,7 +2,7 @@
 /**
  * This file is riddled with @ts-ignore directives,
  * as it uses auto generated file ./base which is not well
- * formatted or well behaved
+ * formatted or well-behaved
  */
 
 import { sharedEnvironment } from './environment.generated';

--- a/ui/apps/ui/src/environments/environment.prod.ts
+++ b/ui/apps/ui/src/environments/environment.prod.ts
@@ -3,5 +3,4 @@ import { commonEnvironment } from './environment.common';
 export const environment = {
   ...commonEnvironment,
   production: true,
-  isSortByRelevance: false,
 };

--- a/ui/apps/ui/src/environments/environment.ts
+++ b/ui/apps/ui/src/environments/environment.ts
@@ -3,5 +3,4 @@ import { commonEnvironment } from './environment.common';
 export const environment = {
   ...commonEnvironment,
   production: false,
-  isSortByRelevance: true,
 };


### PR DESCRIPTION
closes #752

There is a new backend env variable called `IS_SORT_BY_RELEVANCE`. By default, it is set to `False` (now for testing purposes is set to True for @Marcelinna).

@wziajka please set (after merging this PR):
- on beta/PR instances: `IS_SORT_BY_RELEVANCE=True`
- on the production instance, no action is needed, but I suggest setting either way  `IS_SORT_BY_RELEVANCE=False` to be more transparent for future reference. 

@Marcelinna please test this PR.
- Currently, I set `IS_SORT_BY_RELEVANCE=True` (using default) - please look at the instance and confirm that sort by relevance is enabled in proper collections. Then ping me and leave a comment here.
- Secondly, I will set `IS_SORT_BY_RELEVANCE=False`. Once again then, I will ask you to check if sort by relevance is disabled in all collections.
- If all will be okay, we will merge this PR with `IS_SORT_BY_RELEVANCE=False`