### PR TITLE
fix: [#696] aai_uid in sort by relevance

### DIFF
--- a/backend/app/recommender/router_utils/recommendations.py
+++ b/backend/app/recommender/router_utils/recommendations.py
@@ -76,7 +76,7 @@ async def get_recommended_items(client: AsyncClient, uuids: list[str]):
 # pylint: disable=unused-argument
 @alru_cache(maxsize=512)
 async def get_fixed_recommendations(
-    session_id: str | None, panel_id: RecommendationPanelId, count: int = 3
+    panel_id: RecommendationPanelId, count: int = 3
 ) -> list[str]:
     rows = 100
     if panel_id == "data-source":

--- a/backend/app/recommender/router_utils/sort_by_relevance.py
+++ b/backend/app/recommender/router_utils/sort_by_relevance.py
@@ -61,6 +61,7 @@ async def perform_sort_by_relevance(
             "candidates": candidates_ids,
             "search_data": {},
         }
+
         if session is not None:
             request_body["aai_uid"] = session.aai_id
 

--- a/backend/app/routes/web/recommendation.py
+++ b/backend/app/routes/web/recommendation.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 async def get_recommendations(panel_id: RecommendationPanelId, request: Request):
     if settings.SHOW_RECOMMENDATIONS is False:
         return []
-    session, session_id = await get_session(request)
+    session, _ = await get_session(request)
 
     try:
         async with httpx.AsyncClient() as client:
@@ -47,7 +47,7 @@ async def get_recommendations(panel_id: RecommendationPanelId, request: Request)
                 items = await get_recommended_items(client, uuids)
                 return {"recommendations": items, "isRand": False}
             except (RecommenderError, SolrRetrieveError, ReadTimeout) as error:
-                uuids = await get_fixed_recommendations(session_id, panel_id)
+                uuids = await get_fixed_recommendations(panel_id)
                 items = await get_recommended_items(client, uuids)
                 return {
                     "recommendations": items,
@@ -63,17 +63,18 @@ async def get_recommendations(panel_id: RecommendationPanelId, request: Request)
 
 
 async def sort_by_relevance(
+    request: Request,
     panel_id: RecommendationPanelId,
     documents: list,
 ):
-    # session, _ = await get_session(request)
+    session, _ = await get_session(request)
 
     try:
         async with httpx.AsyncClient() as client:
             try:
                 candidates_ids = await parse_candidates(documents)
                 uuids = await perform_sort_by_relevance(
-                    client, None, panel_id, candidates_ids
+                    client, session, panel_id, candidates_ids
                 )
                 items = await sort_docs(uuids, documents)
                 return {"recommendations": items, "message": ""}


### PR DESCRIPTION
closes #696 

The scope is to include the aai_uid of a user in sort by relevance requests. 

I tested that on the PR instance:
- sort by relevance request message from the databus:
```
{'context': {'aai_uid': 'd17380a3d98a019a44ffa6fe9be9f7237359a4300c076a1ee85ff78b5b6b9bc1@egi.eu',
...}
```

- standard recommendations request:
```
{'context': {'aai_uid': 'd17380a3d98a019a44ffa6fe9be9f7237359a4300c076a1ee85ff78b5b6b9bc1@egi.eu',
...}
```

- user_actions
```
("aai_uid": '
 '"d17380a3d98a019a44ffa6fe9be9f7237359a4300c076a1ee85ff78b5b6b9bc1@egi.eu"}')
```

As you can see, everywhere aai_uid is the same. Furthermore, I asked @wziajka to confirm whether that aai_uid is my true aai_uid (in beta MP's DB) and it is proper aai_uid.

