### PR TITLE
fix for long names without space

### DIFF
--- a/ui/apps/ui/src/styles.scss
+++ b/ui/apps/ui/src/styles.scss
@@ -575,9 +575,9 @@ h6 {
 }
 
 .results #container {
-  padding: 10px 20px 25px 0;
+  padding: 10px 0 25px 0;
   position: relative;
-  width: 100%;
+  max-width: 85%;
 
   .usage {
     .open-access {
@@ -605,6 +605,7 @@ h6 {
 
       b {
         font-weight: 600;
+        word-break: break-word;
       }
     }
   }
@@ -655,6 +656,11 @@ h6 {
     margin-bottom: 0;
     margin-top: 5px;
     color: #233d4c;
+
+    span {
+      word-break: break-word;
+      overflow-wrap: break-word;
+    }
   }
 
   .btn-show-more {
@@ -1278,6 +1284,10 @@ h6 {
     ul {
       margin-bottom: 25px;
     }
+  }
+
+  .tag-row .tag-title {
+    flex: 0 0 60px;
   }
 }
 


### PR DESCRIPTION
Added fix for long result titles without any space in one line:

![image](https://github.com/cyfronet-fid/eosc-search-service/assets/8420566/7723cfc9-9eca-4e91-96cd-d23ef3b291f1)

Closes: #888 
