### PR TITLE
bug: fix undefined filterConfig

### DIFF
--- a/ui/apps/ui/src/app/collections/filters-serializers/filters-serializers.utils.ts
+++ b/ui/apps/ui/src/app/collections/filters-serializers/filters-serializers.utils.ts
@@ -86,6 +86,9 @@ export const deserialize = (
   if (isArray(config)) {
     filterConfig = config.find(({ id }) => id === filter) as IFilterConfig;
   }
+  if (filterConfig == null) {
+    return undefined;
+  }
 
   switch (filterConfig.type) {
     case 'tag':


### PR DESCRIPTION
Filters config sometimes is undefined when the user quickly changes collections (looks like 'trainings' tab is triggering the error)

