### PR TITLE
feat: [#928] Correlate visit_id from recommendations with user actions

### DIFF
--- a/backend/app/dependencies/user_actions.py
+++ b/backend/app/dependencies/user_actions.py
@@ -47,6 +47,7 @@ class UserActionClient:
         resource_type: str,
         recommendation: bool,
         target_id: str,
+        recommendation_visit_id: Optional[str],
     ) -> None:
         """Send user data to databus. Ensure that `.connect()` method has been called before."""
 
@@ -61,6 +62,7 @@ class UserActionClient:
                 page_id,
                 recommendation,
                 target_id,
+                recommendation_visit_id,
             )
         )
 
@@ -82,17 +84,20 @@ class UserActionClient:
         page_id: str,
         recommendation: bool,
         target_id: str,
+        recommendation_visit_id: Optional[str],
     ) -> dict:
         """Create valid user action json dict"""
+
+        visit_id = (
+            recommendation_visit_id if recommendation_visit_id else str(uuid.uuid4())
+        )
 
         user_action = {
             "unique_id": session_uuid,
             "client_id": "search_service",
             "timestamp": datetime.datetime.utcnow().isoformat(),
             "source": {
-                # We can generate the source here safely since the
-                # search service is always the root of the UA tree
-                "visit_id": str(uuid.uuid4()),
+                "visit_id": visit_id,
                 # "search/data", "search/publications", "search/software",
                 # "search/services", "search/trainings", - user dashboard - "dashboard"
                 "page_id": page_id,
@@ -151,8 +156,16 @@ def send_user_action_bg_task(
     resource_type: str,
     recommendation: bool,
     target_id: str,
+    recommendation_visit_id: Optional[str],
 ):
     """Simple wrapper function which can be used 'as is' in fastapi's BackgroundTask"""
     client.send(
-        session, url, page_id, resource_id, resource_type, recommendation, target_id
+        session,
+        url,
+        page_id,
+        resource_id,
+        resource_type,
+        recommendation,
+        target_id,
+        recommendation_visit_id,
     )

--- a/backend/app/recommender/router_utils/recommendations.py
+++ b/backend/app/recommender/router_utils/recommendations.py
@@ -18,13 +18,16 @@ from app.solr.operations import get, search
 
 
 async def get_recommended_uuids(
-    client: AsyncClient, session: SessionData | None, collection: Collection
+    client: AsyncClient,
+    session: SessionData | None,
+    collection: Collection,
+    recommendation_visit_id: str,
 ):
     try:
         request_body = {
             "unique_id": session.session_uuid if session else str(uuid.uuid4()),
             "timestamp": datetime.datetime.utcnow().isoformat()[:-3] + "Z",
-            "visit_id": str(uuid.uuid4()),
+            "visit_id": recommendation_visit_id,
             "page_id": "/search/" + collection,
             "panel_id": _get_panel(collection),
             "candidates": {},

--- a/backend/app/routes/web/user_actions.py
+++ b/backend/app/routes/web/user_actions.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-module-docstring
+# pylint: disable=missing-module-docstring, too-many-locals
 import logging
 import urllib.parse
 import uuid
@@ -84,6 +84,10 @@ async def register_navigation_user_action(
         logger.debug("No mqtt client, user action not sent")
         return response
 
+    # For now, the recommendation visit id will be stored in cookies by itself,
+    # not connected to any session.
+    recommendation_visit_id = request.cookies.get("recommendation_visit_id")
+
     background_tasks.add_task(
         send_user_action_bg_task,
         client,
@@ -94,6 +98,7 @@ async def register_navigation_user_action(
         resource_type,
         recommendation,
         str(target_id),
+        recommendation_visit_id,
     )
     return response
 


### PR DESCRIPTION
Closes #928.

recommendation_visit_id is stored in Cookies for the user action request to retrieve it if it's root is in the recommendation panel