### PR TITLE
feat: guidelines & trainings minor improvements

### DIFF
--- a/ui/apps/ui/src/app/collections/data/guidelines/filters.data.ts
+++ b/ui/apps/ui/src/app/collections/data/guidelines/filters.data.ts
@@ -47,7 +47,7 @@ export const guidelinesFilters: IFiltersConfig = {
     {
       id: 'domain',
       filter: 'domain',
-      label: 'Domain',
+      label: 'Scientific Domains',
       type: 'multiselect',
       defaultCollapsed: false,
       tooltipText: '',

--- a/ui/apps/ui/src/app/collections/data/trainings/filters.data.ts
+++ b/ui/apps/ui/src/app/collections/data/trainings/filters.data.ts
@@ -55,8 +55,8 @@ export const trainingsFilters: IFiltersConfig = {
       customSort: alphanumericFilterSort,
     },
     {
-      id: 'eosc_provider',
-      filter: 'eosc_provider',
+      id: 'resource_organisation',
+      filter: 'resource_organisation',
       label: 'Organisation',
       type: 'multiselect',
       defaultCollapsed: false,

--- a/ui/apps/ui/src/app/pages/guidelines-page/guideline-detail-page.component.html
+++ b/ui/apps/ui/src/app/pages/guidelines-page/guideline-detail-page.component.html
@@ -65,41 +65,38 @@
         <div class="ig-middle-wrapper mt-4">
           <div class="row">
             <div class="ig-left-col-desc col-md-9 col-12">
-              <ng-container
-                *ngFor="
-                  let description of this.interoperabilityGuidelineItem
-                    ?.description;
-                  let i = index
-                "
-              >
-                <div class="about-description">
-                  <b>Description:</b> {{ description ?? '' }}
+              <div class="ig-provider-information-wrapper">
+                <div class="ig-header">
+                  <img [src]="'./assets/about.svg'" alt="About" />
+                  <p>About</p>
                 </div>
-              </ng-container>
-
-              <div class="integration-description">
-                <p
-                  i18n
-                  *ngIf="
+                <div class="ig-content-inner">
+                  <span [innerHTML]="this.interoperabilityGuidelineItem?.description ?? '-'"></span>
+                  <br>
+                  <div class="integration-description">
+                    <p
+                      i18n
+                      *ngIf="
                     this.interoperabilityGuidelineItem?.eosc_integration_options
                       ?.length
                   "
-                >
-                  <strong>Integration Options:</strong>
-                </p>
-                <p></p>
-                <ul class="simple-list">
-                  <li
-                    *ngFor="
+                    >
+                      <strong>Integration Options:</strong>
+                    </p>
+                    <p></p>
+                    <ul class="simple-list">
+                      <li
+                        *ngFor="
                       let option of this.interoperabilityGuidelineItem
                         ?.eosc_integration_options
                     "
-                  >
-                    {{ option ?? '' }}
-                  </li>
-                </ul>
+                      >
+                        {{ option ?? '' }}
+                      </li>
+                    </ul>
+                  </div>
+                </div>
               </div>
-
               <div class="ig-provider-information-wrapper">
                 <div class="ig-header">
                   <img src="assets/icon-creators.svg" alt="Creators" />

--- a/ui/apps/ui/src/app/pages/trainings-page/training-detail-page.component.html
+++ b/ui/apps/ui/src/app/pages/trainings-page/training-detail-page.component.html
@@ -51,7 +51,7 @@
                   <p>About</p>
                 </div>
                 <div class="ig-content-inner">
-                  <p>{{ myTraining?.description ?? '-' }}</p>
+                  <span [innerHTML]="myTraining?.description ?? '-'"></span>
                 </div>
               </div>
 
@@ -111,14 +111,14 @@
                   </div>
                 </div>
               </div>
-              <div class="keywords-container">
+              <div class="keywords-container" *ngIf="myTraining.keywords && myTraining.keywords.length > 0">
                 <p>
                   Keywords:
                   <ng-container *ngFor="let key of myTraining.keywords">
                     <a
                       [routerLink]="['/search/all']"
                       [queryParams]="keywordQueryParam(key)"
-                      ><span class="key">{{ key }}</span></a
+                    ><span class="key">{{ key }}</span></a
                     >
                   </ng-container>
                 </p>


### PR DESCRIPTION
closes #1009 

Scope:
1) html in guidelines and training descriptions should be handled. Guideline that has HTML [link](https://search-6.docker-fid.grid.cyf-kr.edu.pl/guidelines/eosc.85d3f1ab01e8fa7070a5a30f3b504644?return_path=search%2Fguideline&search_params=q%3D*%26standard%3Dtrue%26exact%3Dfalse%26radioValueAuthor%3DA%26radioValueExact%3DA%26radioValueTitle%3DA%26radioValueKeyword%3DA&source_id=68e03658-fa3d-466a-9a83-0e593333e2a6&client_uid=bc58a410-1763-4200-b01e-51e707281144)
2) the same good-looking description in guidelines as it is in trainings (About)
3) providers -> organizations data switch in trainings organizations filter 
4) rename domain -> scientific domains filter in guidelines
5) keywords in trainings detail page are shown when their len >  0. Training that has 0 keywords (test purpose) [url](https://beta.search.marketplace.eosc-portal.eu/trainings/eosc.ap.dbabdefc29ff0d9c4b1f93a87961dcc7?return_path=search%2Ftraining&search_params=q%3D*%26standard%3Dtrue%26exact%3Dfalse%26radioValueAuthor%3DA%26radioValueExact%3DA%26radioValueTitle%3DA%26radioValueKeyword%3DA&source_id=63cd2348-2e44-4558-a289-917eed208725&client_uid=6d65bdb3-25ee-4a30-a130-5c5faad2efd1)