### PR TITLE
fix: [#1108] keywords for mp resources - workaround 

### DIFF
--- a/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
@@ -219,7 +219,7 @@ export const allCollectionsAdapter: IAdapter = {
     collection: COLLECTION,
     secondaryTags: [
       toInterPatternsSecondaryTag(data.eosc_if ?? [], 'eosc_if'),
-      toKeywordsSecondaryTag(data.tag_list ?? [], 'tag_list'),
+      toKeywordsSecondaryTag(data.keywords ?? [], 'keywords'),
     ],
     offers: data.offers ?? [],
     ...parseStatistics(data),


### PR DESCRIPTION
closes #1108 