### PR TITLE
feat: [#1121] speed up search

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ See docker-compose.yml for components.
   > Boolean variable that indicates whether sort by relevance should be enabled on the instance level. Default: False.
 - `MAX_RESULTS_BY_PAGE`
   > Integer specifying how many results to fetch with a single call to SOLR backend
+- `MAX_ITEMS_SORT_RELEVANCE`
+  > Integer specifying the maximum number of resources sorted by relevance by the RS.
+
 
 `db` envs:
 - `DB_POSTGRES_DB`

--- a/backend/app/routes/web/configuration.py
+++ b/backend/app/routes/web/configuration.py
@@ -19,4 +19,5 @@ async def config():
         knowledge_hub_url=settings.KNOWLEDGE_HUB_URL,
         is_sort_by_relevance=settings.IS_SORT_BY_RELEVANCE,
         max_results_by_page=settings.MAX_RESULTS_BY_PAGE,
+        max_items_sort_relevance=settings.MAX_ITEMS_SORT_RELEVANCE,
     )

--- a/backend/app/routes/web/search_results.py
+++ b/backend/app/routes/web/search_results.py
@@ -21,6 +21,7 @@ from app.consts import (
 from app.routes.web.recommendation import sort_by_relevance
 from app.schemas.search_request import SearchRequest
 from app.schemas.solr_response import Collection, ExportData
+from app.settings import settings
 from app.solr.error_handling import SolrDocumentNotFoundError
 from app.solr.operations import get, search_advanced_dep, search_dep
 from app.utils.ig_related_services import extend_ig_with_related_services
@@ -77,7 +78,7 @@ async def search_post(
             qf=qf,
             fq=fq,
             sort=final_solr_sorting,
-            rows=rows,
+            rows=settings.MAX_ITEMS_SORT_RELEVANCE if sort_ui == "r" else rows,
             exact=exact,
             cursor=cursor,
             facets=request.facets,
@@ -148,7 +149,7 @@ async def search_post_advanced(
             qf=qf,
             fq=fq,
             sort=final_solr_sorting,
-            rows=rows,
+            rows=settings.MAX_ITEMS_SORT_RELEVANCE if sort_ui == "r" else rows,
             exact=exact,
             cursor=cursor,
             facets=request.facets,

--- a/backend/app/schemas/configuration_response.py
+++ b/backend/app/schemas/configuration_response.py
@@ -10,3 +10,4 @@ class ConfigurationResponse(BaseModel):
     knowledge_hub_url: AnyHttpUrl
     is_sort_by_relevance: bool
     max_results_by_page: int
+    max_items_sort_relevance: int

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -62,8 +62,9 @@ class GlobalSettings(BaseSettings):
     EOSC_EXPLORE_URL: AnyUrl = "https://explore.eosc-portal.eu"
     KNOWLEDGE_HUB_URL: AnyUrl = "https://knowledge-hub.eosc-portal.eu/"
     RELATED_SERVICES_ENDPOINT: AnyUrl = "https://beta.providers.eosc-portal.eu/api/public/interoperabilityRecord/relatedResources"
-    IS_SORT_BY_RELEVANCE: bool = False
-    MAX_RESULTS_BY_PAGE: int = 250
+    IS_SORT_BY_RELEVANCE: bool = True
+    MAX_RESULTS_BY_PAGE: int = 50
+    MAX_ITEMS_SORT_RELEVANCE: int = 250
 
     COLLECTIONS_PREFIX: str = ""
 

--- a/backend/tests/app/routes/test_configuration.py
+++ b/backend/tests/app/routes/test_configuration.py
@@ -16,6 +16,7 @@ async def test_return_backend_config(app: FastAPI, client: AsyncClient) -> None:
         "marketplace_url": "https://marketplace.eosc-portal.eu",
         "eosc_explore_url": "https://explore.eosc-portal.eu",
         "knowledge_hub_url": "https://knowledge-hub.eosc-portal.eu/",
-        "is_sort_by_relevance": False,
-        "max_results_by_page": 250,
+        "is_sort_by_relevance": True,
+        "max_results_by_page": 50,
+        "max_items_sort_relevance": 250,
     }

--- a/ui/apps/ui/src/app/pages/search-page/utils.ts
+++ b/ui/apps/ui/src/app/pages/search-page/utils.ts
@@ -248,4 +248,4 @@ export function constructStandardSearchMetadata(
 }
 
 export const getMaxResultsByPage = () =>
-  ConfigService.config?.max_results_by_page ?? 250;
+  ConfigService.config?.max_results_by_page ?? 50;


### PR DESCRIPTION
closes #1121 

- powrot do zaciagania 50 resourcow (5 pages) na raz,
- do sort by relevance nadal leci 250 resourcow - stworzylem zmienna srodowiskowa do latwej manipulacji tej liczby

Jak testowac?
- powinien sie zmniejszyc czas dociagania search-results - mozna to podejrzec w network. Porownujmy ten czas z beta.
- warto zwrocic uwage, ze czas dociagania filtrow sie nie zmniejszyl (request search-filters), wiec zdarza sie sytuacja w ktorej rezultaty sie juz dawno temu dociagnely, ale nadal strona czeka na filtry
- zauwazylem, ze pierwsze dociagniecie danych w danej zakladce jest zdecydowanie wolniejsze,
- najwolniejsze kolekcje to zdecydowanie all_collection, publication oraz dataset 