### PR TITLE
feat: add catalogues collection

### DIFF
--- a/backend/app/consts.py
+++ b/backend/app/consts.py
@@ -18,6 +18,7 @@ class ResourceType(str, Enum):
     PROVIDER = "provider"
     ORGANISATION = "organisation"
     PROJECT = "project"
+    CATALOGUE = "catalogue"
 
 
 class Collection(str, Enum):
@@ -37,6 +38,7 @@ class Collection(str, Enum):
     OFFER = "offer"
     ORGANISATION = "organisation"
     PROJECT = "project"
+    CATALOGUE = "catalogue"
 
 
 ALL_COLLECTION_LIST = [
@@ -50,7 +52,6 @@ ALL_COLLECTION_LIST = [
     Collection.BUNDLE,
     Collection.OTHER_RP,
     Collection.PROVIDER,
-    Collection.ORGANISATION,
 ]
 
 
@@ -107,6 +108,8 @@ PANEL_ID_OPTIONS = [
 ]
 
 SPECIAL_COLLECTIONS = [Collection.PROJECT, Collection.ORGANISATION]
+
+CATALOGUE_QF = "title^100 abbreviation^100 description^10 keywords_tg^10"
 
 PROVIDER_QF = "title^100 description^10 scientific_domains^10"
 

--- a/backend/app/routes/web/user_actions.py
+++ b/backend/app/routes/web/user_actions.py
@@ -46,6 +46,7 @@ async def register_navigation_user_action(
         "provider",
         "project",
         "organisation",
+        "catalogue",
     ],
     page_id: str,
     recommendation: bool = False,

--- a/backend/app/solr/operations.py
+++ b/backend/app/solr/operations.py
@@ -5,7 +5,13 @@ from typing import Dict
 
 from httpx import AsyncClient, Response
 
-from app.consts import DEFAULT_QF, ORGANISATION_QF, PROJECT_QF, PROVIDER_QF
+from app.consts import (
+    CATALOGUE_QF,
+    DEFAULT_QF,
+    ORGANISATION_QF,
+    PROJECT_QF,
+    PROVIDER_QF,
+)
 from app.schemas.search_request import StatFacet, TermsFacet
 from app.schemas.solr_response import Collection, SolrResponse
 from app.settings import settings
@@ -246,6 +252,8 @@ async def _check_collection_sanity(client, collection):
         qf = ORGANISATION_QF
     elif collection == Collection.PROJECT:
         qf = PROJECT_QF
+    elif collection == Collection.CATALOGUE:
+        qf = CATALOGUE_QF
 
     else:
         qf = DEFAULT_QF
@@ -260,10 +268,7 @@ async def _check_collection_sanity(client, collection):
             "hl.method": "fastVector",
             "q": "*",
             "qf": qf,
-            "pf": (
-                "title^100 author_names_tg^120 description^10 keywords_tg^10"
-                " tag_list_tg^10"
-            ),
+            "pf": qf,
             "fq": [],
             "rows": 1,
             "cursorMark": "*",
@@ -271,10 +276,10 @@ async def _check_collection_sanity(client, collection):
             "wt": "json",
         }
     }
-
+    solr_collection = f"{settings.COLLECTIONS_PREFIX}{collection}"
     response = await handle_solr_list_response_errors(
         client.post(
-            f"{settings.SOLR_URL}{collection}/select",
+            f"{settings.SOLR_URL}{solr_collection}/select",
             json=request_body,
         )
     )

--- a/backend/tests/app/routes/test_suggestions.py
+++ b/backend/tests/app/routes/test_suggestions.py
@@ -61,7 +61,7 @@ async def test_suggestions_dispatch_collections(
         json={},
     )
     assert res.status_code == status.HTTP_200_OK
-    assert mock_post_search.call_count == 11
+    assert mock_post_search.call_count == 10
 
 
 @pytest.mark.parametrize(

--- a/ui/apps/ui/src/app/collections/data/catalogues/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/catalogues/adapter.data.ts
@@ -1,0 +1,51 @@
+import { IAdapter, IResult } from '../../repositories/types';
+import { URL_PARAM_NAME } from './nav-config.data';
+import { COLLECTION } from './search-metadata.data';
+import { ICatalogue } from './catalogue.model';
+import {
+  toArray,
+  toValueWithLabel,
+} from '@collections/filters-serializers/utils';
+import { ConfigService } from '../../../services/config.service';
+import {
+  formatPublicationDate,
+  toKeywordsSecondaryTag,
+} from '@collections/data/utils';
+
+export const cataloguesAdapter: IAdapter = {
+  id: URL_PARAM_NAME,
+  adapter: (catalogue: Partial<ICatalogue> & { id: string }): IResult => ({
+    id: catalogue.id,
+    pid: catalogue.pid,
+    type: {
+      label: 'catalogue',
+      value: 'catalogue',
+    },
+    tags: [
+      {
+        label: 'Scientific domain',
+        values: toValueWithLabel(toArray(catalogue.scientific_domains)),
+        filter: 'scientific_domains',
+      },
+      {
+        label: 'Legal status',
+        values: toValueWithLabel(toArray(catalogue.legal_status)),
+        filter: 'legal_status',
+      },
+    ],
+    collection: COLLECTION,
+    title: catalogue.title ?? '',
+    abbreviation: catalogue.abbreviation ?? '',
+    description: [catalogue?.description]?.join(' ') || '',
+    date: formatPublicationDate(catalogue['publication_date']),
+    secondaryTags: [
+      toKeywordsSecondaryTag(catalogue.keywords ?? [], 'keywords'),
+    ],
+
+    url: catalogue.pid
+      ? `${ConfigService.config?.marketplace_url}/catalogues/${catalogue.pid}`
+      : '',
+    coloredTags: [],
+    isResearchProduct: false,
+  }),
+};

--- a/ui/apps/ui/src/app/collections/data/catalogues/catalogue.model.ts
+++ b/ui/apps/ui/src/app/collections/data/catalogues/catalogue.model.ts
@@ -1,0 +1,14 @@
+import { IValueWithLabel } from '@collections/repositories/types';
+
+export interface ICatalogue {
+  id: string;
+  title: string;
+  abbreviation: string;
+  description: string;
+  legal_status: string[];
+  scientific_domains: string[];
+  keywords: string[];
+  publication_date: string;
+  pid: string;
+  type: IValueWithLabel;
+}

--- a/ui/apps/ui/src/app/collections/data/catalogues/excluded.data.ts
+++ b/ui/apps/ui/src/app/collections/data/catalogues/excluded.data.ts
@@ -1,0 +1,7 @@
+import { URL_PARAM_NAME } from '@collections/data/catalogues/nav-config.data';
+import { IExcludedFiltersConfig } from '@collections/repositories/types';
+
+export const excludedCatalogueFilters: IExcludedFiltersConfig = {
+  id: URL_PARAM_NAME,
+  excluded: ['language'],
+};

--- a/ui/apps/ui/src/app/collections/data/catalogues/filters.data.ts
+++ b/ui/apps/ui/src/app/collections/data/catalogues/filters.data.ts
@@ -1,0 +1,52 @@
+import { IFiltersConfig } from '../../repositories/types';
+import { URL_PARAM_NAME } from './nav-config.data';
+
+export const catalogueFilters: IFiltersConfig = {
+  id: URL_PARAM_NAME,
+  filters: [
+    {
+      id: 'scientific_domains',
+      filter: 'scientific_domains',
+      label: 'Scientific domain',
+      type: 'multiselect',
+      defaultCollapsed: false,
+      tooltipText: '',
+      expandArrow: true,
+    },
+    {
+      id: 'legal_status',
+      filter: 'legal_status',
+      label: 'Legal status',
+      type: 'multiselect',
+      defaultCollapsed: false,
+      tooltipText: '',
+      expandArrow: true,
+    },
+    {
+      id: 'scientific_domains',
+      filter: 'scientific_domains',
+      label: 'Scientific domain',
+      type: 'tag',
+      defaultCollapsed: false,
+      tooltipText: '',
+      expandArrow: true,
+    },
+    {
+      id: 'legal_status',
+      filter: 'legal_status',
+      label: 'Legal status',
+      type: 'tag',
+      defaultCollapsed: false,
+      tooltipText: '',
+      expandArrow: true,
+    },
+    {
+      id: 'keywords',
+      filter: 'keywords',
+      label: 'Keywords',
+      type: 'tag',
+      defaultCollapsed: false,
+      tooltipText: '',
+    },
+  ],
+};

--- a/ui/apps/ui/src/app/collections/data/catalogues/nav-config.data.ts
+++ b/ui/apps/ui/src/app/collections/data/catalogues/nav-config.data.ts
@@ -2,9 +2,9 @@ import { ICollectionNavConfig } from '../../repositories/types';
 import { LABEL as ALL_COLLECTIONS_LABEL } from '../all/nav-config.data';
 import { URL_PARAM_NAME as ALL_COLLECTIONS_URL_PARAM_NAME } from '../all/nav-config.data';
 
-export const URL_PARAM_NAME = 'project';
-export const LABEL = 'Projects';
-export const projectNavConfig: ICollectionNavConfig = {
+export const URL_PARAM_NAME = 'catalogue';
+export const LABEL = 'Catalogues';
+export const cataloguesNavConfig: ICollectionNavConfig = {
   id: URL_PARAM_NAME,
   title: LABEL,
   breadcrumbs: [
@@ -17,7 +17,7 @@ export const projectNavConfig: ICollectionNavConfig = {
     },
   ],
   urlParam: URL_PARAM_NAME,
-  rightMenu: false,
+  rightMenu: true,
   isSortByRelevanceCollectionScopeOff: true,
   isSortByPopularityCollectionScopeOff: true,
 };

--- a/ui/apps/ui/src/app/collections/data/catalogues/search-metadata.data.ts
+++ b/ui/apps/ui/src/app/collections/data/catalogues/search-metadata.data.ts
@@ -1,0 +1,13 @@
+import { URL_PARAM_NAME } from './nav-config.data';
+import { ICollectionSearchMetadata } from '../../repositories/types';
+import { CATALOGUE_QF, DEFAULT_FACET } from '@collections/data/config';
+
+export const COLLECTION = 'catalogue';
+export const cataloguesSearchMetadata: ICollectionSearchMetadata = {
+  id: URL_PARAM_NAME,
+  facets: DEFAULT_FACET,
+  params: {
+    qf: CATALOGUE_QF,
+    collection: COLLECTION,
+  },
+};

--- a/ui/apps/ui/src/app/collections/data/config.ts
+++ b/ui/apps/ui/src/app/collections/data/config.ts
@@ -8,15 +8,35 @@ export const DEFAULT_FACET: { [field: string]: ITermsFacetParam } = {
 export const DEFAULT_QF =
   'title^100 author_names_tg^120 description^10 keywords_tg^10 tag_list_tg^10';
 
-export const PROVIDER_QF = 'title^100 description^10 scientific_domains^10';
+export const PROVIDER_QF =
+  'title^100 abbreviation^100 description^10 scientific_domains^10';
 
-export const PROJECT_QF = 'title^ description^10 keywords_tg^10';
+export const CATALOGUE_QF =
+  'title^100 abbreviation^100 description^10 keywords_tg^10';
+
+export const PROJECT_QF =
+  'title^100 abbreviation^100 description^10 keywords_tg^10';
 
 export const ORGANISATION_QF = 'alternative_names title abbreviation';
 
-export const SPECIAL_COLLECTIONS = ['organisation', 'provider', 'project'];
+export const SPECIAL_COLLECTIONS = [
+  'organisation',
+  'provider',
+  'project',
+  'catalogue',
+];
 
 export const BETA_ONLY_COLLECTIONS = ['organisation', 'project'];
+
+export const NO_RECOMMENDATIONS_COLLECTIONS = [
+  'guideline',
+  'provider',
+  'bundle',
+  'data_source',
+  'organisation',
+  'project',
+  'catalogue',
+];
 
 export const HORIZONTAL_TOOLTIP_TEXT =
   'Horizontal Services are services potentially useful for all researchers' +

--- a/ui/apps/ui/src/app/collections/data/index.ts
+++ b/ui/apps/ui/src/app/collections/data/index.ts
@@ -10,29 +10,7 @@ import { guidelinesNavConfig } from './guidelines/nav-config.data';
 import { providersNavConfig } from '@collections/data/providers/nav-config.data';
 import { projectNavConfig } from './projects/nav-config.data';
 import { organisationsNavConfig } from './organisations/nav-config.data';
-import { trainingsAdapter } from './trainings/adapter.data';
-import { guidelinesAdapter } from './guidelines/adapter.data';
-import { trainingsSearchMetadata } from './trainings/search-metadata.data';
-import { guidelinesSearchMetadata } from './guidelines/search-metadata.data';
-import { providersSearchMetadata } from './providers/search-metadata.data';
-import { projectsSearchMetadata } from './projects/search-metadata.data';
-import { organisationsSearchMetadata } from './organisations/search-metadata.data';
-
-import { allCollectionsAdapter } from './all/adapter.data';
-import { publicationsAdapter } from './publications/adapter.data';
-import { datasetsAdapter } from './datasets/adapter.data';
-import { softwareAdapter } from './software/adapter.data';
-import { dataSourcesAdapter } from './data-sources/adapter.data';
-import { allCollectionsFilters } from './all/filters.data';
-import { publicationsFilters } from './publications/filters.data';
-import { datasetsFilters } from './datasets/filters.data';
-import { softwareFilters } from './software/filters.data';
-import { dataSourcesFilters } from './data-sources/filters.data';
-import { trainingsFilters } from './trainings/filters.data';
-import { guidelinesFilters } from './guidelines/filters.data';
-import { providersAdapter } from '@collections/data/providers/adapter.data';
-import { projectsAdapter } from './projects/adapter.data';
-import { organisationsAdapter } from './organisations/adapter.data';
+import { cataloguesNavConfig } from './catalogues/nav-config.data';
 import {
   URL_PARAM_NAME as ALL_COLLECTIONS_URL_PARAM_NAME,
   allCollectionsNavConfig,
@@ -41,28 +19,55 @@ import { publicationsNavConfig } from './publications/nav-config.data';
 import { datasetsNavConfig } from './datasets/nav-config.data';
 import { softwareNavConfig } from './software/nav-config.data';
 import { dataSourcesNavConfig } from './data-sources/nav-config.data';
+import { servicesNavConfig } from '@collections/data/services/nav-config.data';
+import { othersResourcesProductsNavConfig } from '@collections/data/other-resources-products/nav-config.data';
+import { bundlesNavConfig } from '@collections/data/bundles/nav-config.data';
+
+import { trainingsAdapter } from './trainings/adapter.data';
+import { guidelinesAdapter } from './guidelines/adapter.data';
+import { allCollectionsAdapter } from './all/adapter.data';
+import { publicationsAdapter } from './publications/adapter.data';
+import { datasetsAdapter } from './datasets/adapter.data';
+import { softwareAdapter } from './software/adapter.data';
+import { dataSourcesAdapter } from './data-sources/adapter.data';
+import { providersAdapter } from '@collections/data/providers/adapter.data';
+import { projectsAdapter } from './projects/adapter.data';
+import { organisationsAdapter } from './organisations/adapter.data';
+import { servicesAdapter } from '@collections/data/services/adapter.data';
+import { otherResourcesProductsAdapter } from '@collections/data/other-resources-products/adapter.data';
+import { bundlesAdapter } from '@collections/data/bundles/adapter.data';
+import { cataloguesAdapter } from './catalogues/adapter.data';
+
+import { trainingsSearchMetadata } from './trainings/search-metadata.data';
+import { guidelinesSearchMetadata } from './guidelines/search-metadata.data';
+import { providersSearchMetadata } from './providers/search-metadata.data';
+import { projectsSearchMetadata } from './projects/search-metadata.data';
+import { organisationsSearchMetadata } from './organisations/search-metadata.data';
 import { allCollectionsSearchMetadata } from './all/search-metadata.data';
 import { publicationsSearchMetadata } from './publications/search-metadata.data';
 import { datasetsSearchMetadata } from './datasets/search-metadata.data';
 import { softwareSearchMetadata } from './software/search-metadata.data';
 import { dataSourcesSearchMetadata } from './data-sources/search-metadata.data';
-import { servicesAdapter } from '@collections/data/services/adapter.data';
-import { servicesFilters } from '@collections/data/services/filters.data';
 import { servicesSearchMetadata } from '@collections/data/services/search-metadata.data';
+import { otherResourcesProductsSearchMetadata } from '@collections/data/other-resources-products/search-metadata.data';
+import { bundlesSearchMetadata } from '@collections/data/bundles/search-metadata.data';
+import { cataloguesSearchMetadata } from './catalogues/search-metadata.data';
+
+import { allCollectionsFilters } from './all/filters.data';
+import { publicationsFilters } from './publications/filters.data';
+import { datasetsFilters } from './datasets/filters.data';
+import { softwareFilters } from './software/filters.data';
+import { dataSourcesFilters } from './data-sources/filters.data';
+import { trainingsFilters } from './trainings/filters.data';
+import { guidelinesFilters } from './guidelines/filters.data';
+import { servicesFilters } from '@collections/data/services/filters.data';
 import { providersFilters } from '@collections/data/providers/filters.data';
 import { projectsFilters } from './projects/filters.data';
 import { organisationsFilters } from './organisations/filters.data';
-
-import { validateCollections } from '@collections/data/validators';
-import { servicesNavConfig } from '@collections/data/services/nav-config.data';
 import { otherResourcesProductsFilters } from '@collections/data/other-resources-products/filters.data';
-import { othersResourcesProductsNavConfig } from '@collections/data/other-resources-products/nav-config.data';
-import { otherResourcesProductsSearchMetadata } from '@collections/data/other-resources-products/search-metadata.data';
-import { otherResourcesProductsAdapter } from '@collections/data/other-resources-products/adapter.data';
-import { bundlesNavConfig } from '@collections/data/bundles/nav-config.data';
-import { bundlesSearchMetadata } from '@collections/data/bundles/search-metadata.data';
 import { bundlesFilters } from '@collections/data/bundles/filters.data';
-import { bundlesAdapter } from '@collections/data/bundles/adapter.data';
+import { catalogueFilters } from './catalogues/filters.data';
+
 import { excludedPublicationsFilters } from '@collections/data/publications/excluded.data';
 import { excludedDatasetsFilters } from '@collections/data/datasets/excluded.data';
 import { excludedAllCollectionsFilters } from '@collections/data/all/excluded.data';
@@ -76,6 +81,9 @@ import { excludedBundlesFilters } from '@collections/data/bundles/excluded.data'
 import { excludedProvidersFilters } from '@collections/data/providers/excluded.data';
 import { excludedProjectFilters } from './projects/excluded.data';
 import { excludedOrganisationFilters } from './organisations/excluded.data';
+import { excludedCatalogueFilters } from './catalogues/excluded.data';
+
+import { validateCollections } from '@collections/data/validators';
 
 export const DEFAULT_COLLECTION_ID = ALL_COLLECTIONS_URL_PARAM_NAME;
 export const ADAPTERS: IAdapter[] = [
@@ -92,6 +100,7 @@ export const ADAPTERS: IAdapter[] = [
   providersAdapter,
   projectsAdapter,
   organisationsAdapter,
+  cataloguesAdapter,
 ];
 export const FILTERS: IFiltersConfig[] = [
   allCollectionsFilters,
@@ -107,6 +116,7 @@ export const FILTERS: IFiltersConfig[] = [
   providersFilters,
   projectsFilters,
   organisationsFilters,
+  catalogueFilters,
 ];
 
 // Excluded filters according to adjustments in
@@ -125,6 +135,7 @@ export const EXCLUDED_FILTERS: IExcludedFiltersConfig[] = [
   excludedProvidersFilters,
   excludedProjectFilters,
   excludedOrganisationFilters,
+  excludedCatalogueFilters,
 ];
 
 export const NAV_CONFIGS: ICollectionNavConfig[] = [
@@ -141,6 +152,7 @@ export const NAV_CONFIGS: ICollectionNavConfig[] = [
   providersNavConfig,
   projectNavConfig,
   organisationsNavConfig,
+  cataloguesNavConfig,
 ];
 export const SEARCH_METADATA: ICollectionSearchMetadata[] = [
   allCollectionsSearchMetadata,
@@ -156,6 +168,7 @@ export const SEARCH_METADATA: ICollectionSearchMetadata[] = [
   providersSearchMetadata,
   projectsSearchMetadata,
   organisationsSearchMetadata,
+  cataloguesSearchMetadata,
 ];
 
 validateCollections(

--- a/ui/apps/ui/src/app/collections/data/organisations/nav-config.data.ts
+++ b/ui/apps/ui/src/app/collections/data/organisations/nav-config.data.ts
@@ -18,6 +18,6 @@ export const organisationsNavConfig: ICollectionNavConfig = {
   ],
   urlParam: URL_PARAM_NAME,
   rightMenu: true,
-  isSortByRelevanceCollectionScopeOff: false,
-  isSortByPopularityCollectionScopeOff: false,
+  isSortByRelevanceCollectionScopeOff: true,
+  isSortByPopularityCollectionScopeOff: true,
 };

--- a/ui/apps/ui/src/app/collections/repositories/types.ts
+++ b/ui/apps/ui/src/app/collections/repositories/types.ts
@@ -60,6 +60,7 @@ export interface IResult {
   relatedProjectNumber?: number;
   relatedSoftwareNumber?: number;
   relatedOrganisationTitles?: string[];
+  pid?: string;
 }
 
 export interface RelatedService {

--- a/ui/apps/ui/src/app/components/recommendations/recommendations.component.ts
+++ b/ui/apps/ui/src/app/components/recommendations/recommendations.component.ts
@@ -16,6 +16,7 @@ import {
   RECOMMENDATIONS_TOOLTIP_TEXT_NOTLOGGED,
 } from '@collections/data/config';
 import { UserProfileService } from '../../auth/user-profile.service';
+import { NO_RECOMMENDATIONS_COLLECTIONS } from '@collections/data/config';
 
 @UntilDestroy()
 @Component({
@@ -46,14 +47,7 @@ export class RecommendationsComponent implements OnInit {
       .pipe(
         untilDestroyed(this),
         switchMap((panelId) => {
-          if (
-            panelId === 'guideline' ||
-            panelId === 'provider' ||
-            panelId === 'bundle' ||
-            panelId === 'data_source' ||
-            panelId === 'organisation' ||
-            panelId === 'project'
-          ) {
+          if (NO_RECOMMENDATIONS_COLLECTIONS.includes(panelId)) {
             return of([]);
           }
           return this._recommendationsService

--- a/ui/apps/ui/src/app/components/results-with-pagination/result-ui-controls/show-related-resources.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/result-ui-controls/show-related-resources.ts
@@ -3,7 +3,7 @@ import { DEFAULT_COLLECTION_ID } from '@collections/data';
 import { SEARCH_PAGE_PATH } from '@collections/services/custom-route.type';
 
 @Component({
-  selector: 'ess-relatd-resources',
+  selector: 'ess-related-resources',
   template: `
     <a style="display: flex;" [attr.href]="url">
       <span class="show-resources-icon"></span>
@@ -14,17 +14,19 @@ import { SEARCH_PAGE_PATH } from '@collections/services/custom-route.type';
 })
 export class ShowRelatedResourceComponent implements OnInit {
   @Input() public title = '';
-  @Input() public id = '';
+  @Input() public pid = '';
   @Input() public collection: string = '';
   public url = '';
   public label: string = '';
 
   setUrl(): string {
-    const fqs =
-      this.collection === 'provider'
-        ? `fq=providers:"${this.title}"&fq=resource_organisation:"${this.title}"`
-        : `fq=related_organisation_titles:"${this.title}"`;
+    const fqDict: { [key: string]: string } = {
+      provider: `fq=providers:"${this.title}"&fq=resource_organisation:"${this.title}"`,
 
+      organisation: `fq=related_organisation_titles:"${this.title}"`,
+      catalogue: `fq=catalogue:"${this.pid}"`,
+    };
+    const fqs = fqDict[this.collection];
     const url = `${SEARCH_PAGE_PATH}/${DEFAULT_COLLECTION_ID}?q=*&${fqs}`;
 
     return url;
@@ -32,7 +34,6 @@ export class ShowRelatedResourceComponent implements OnInit {
 
   ngOnInit() {
     this.url = this.setUrl();
-    this.label =
-      this.collection === 'provider' ? 'Show Resources' : 'Show Resources';
+    this.label = 'Show Resources';
   }
 }

--- a/ui/apps/ui/src/app/components/results-with-pagination/result.component.html
+++ b/ui/apps/ui/src/app/components/results-with-pagination/result.component.html
@@ -52,6 +52,7 @@
         >
         </ess-url-title>
         <ess-url-title
+        *ngIf="abbreviation"
           [ngClass]="{ sub_title: this.isSpecialCollection }"
           [title]="abbreviation"
           [highlight]="highlightsreal['abbreviation'] ?? []"
@@ -293,11 +294,12 @@
       [url]="redirectOrderUrl"
       style="float: left"
     ></ess-pin-static>
-    <div *ngIf="collection === 'provider' || collection === 'organisation'">
-      <ess-relatd-resources
+    <div *ngIf="collection === 'provider' || collection === 'organisation' || collection === 'catalogue' ">
+      <ess-related-resources
+        [pid]="this.pid ?? ''"
         [title]="title"
         [collection]="collection"
-      ></ess-relatd-resources>
+      ></ess-related-resources>
     </div>
 
   </div>

--- a/ui/apps/ui/src/app/components/results-with-pagination/result.component.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/result.component.ts
@@ -39,6 +39,7 @@ export class ResultComponent implements OnInit {
 
   @Input() id!: string;
   @Input() date?: string;
+  @Input() pid?: string = '';
   @Input() urls: string[] = [];
 
   @Input() isResearchProduct = false;
@@ -417,6 +418,7 @@ export class ResultComponent implements OnInit {
         provider: 'Provider',
         project: 'Project',
         organisation: 'Organisation',
+        catalogue: 'Catalogue',
         'data source': 'Data Source',
         'interoperability guideline': 'Interoperability Guideline',
       };

--- a/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.html
+++ b/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.html
@@ -117,7 +117,30 @@
         [relatedOtherNumber]="result.relatedOtherNumber ?? 0"
         [relatedProjectNumber]="result.relatedProjectNumber ?? 0"
       ></ess-result>
-
+      <ess-result
+      *ngIf="
+        result.type.value.toString().includes('catalogue')"
+      class="results organisation"
+      [id]="result.id"
+      [title]="result.title"
+      [abbreviation]="result.abbreviation ?? ''"
+      [pid]="result.pid ?? ''"
+      [description]="result.description | transformArrayDescriptionPipe"
+      [tags]="result.tags"
+      [coloredTags]="result.coloredTags ?? []"
+      [secondaryTags]="result.secondaryTags ?? []"
+      [type]="result.type"
+      [country]="result.country ?? ''"
+      [website]="result.website ?? ''"
+      [url]="result.url"
+      [highlights]="highlights[result.id] ?? {}"
+      [isResearchProduct]="result.isResearchProduct"
+      [relatedPublicationNumber]="result.relatedPublicationNumber ?? 0"
+      [relatedSoftwareNumber]="result.relatedSoftwareNumber ?? 0"
+      [relatedDatasetNumber]="result.relatedDatasetNumber ?? 0"
+      [relatedOtherNumber]="result.relatedOtherNumber ?? 0"
+      [relatedProjectNumber]="result.relatedProjectNumber ?? 0"
+    ></ess-result>
       <ess-result
         *ngIf="
           result.type.value.toString().includes('provider')"

--- a/ui/apps/ui/src/app/components/search-input/search-input.component.html
+++ b/ui/apps/ui/src/app/components/search-input/search-input.component.html
@@ -78,7 +78,7 @@
           </span>
         </div>
       </div>
-     <div *ngIf="!isOrganisationCollection && !isProjectCollection"> 
+     <div *ngIf="!isAdvancedSearchOff"> 
       <span
       *ngIf="!isLanding()"
       class="adv-search-text-btn"

--- a/ui/apps/ui/src/app/components/search-input/search-input.component.ts
+++ b/ui/apps/ui/src/app/components/search-input/search-input.component.ts
@@ -76,8 +76,7 @@ export class SearchInputComponent implements OnInit {
     { name: 'None of' },
   ];
   isSpecialCollection = false;
-  isOrganisationCollection = false;
-  isProjectCollection = false;
+  isAdvancedSearchOff = false;
 
   faMagnifyingGlass = faMagnifyingGlass;
   formControl = new UntypedFormControl();
@@ -232,8 +231,12 @@ export class SearchInputComponent implements OnInit {
   ngOnInit() {
     this._customRoute.collection$.subscribe((val) => {
       this.isSpecialCollection = SPECIAL_COLLECTIONS.includes(val);
-      this.isOrganisationCollection = val === 'organisation';
-      this.isProjectCollection = val === 'project';
+      const advSearchExcludeCollections = [
+        'organisation',
+        'project',
+        'catalogue',
+      ];
+      this.isAdvancedSearchOff = advSearchExcludeCollections.includes(val);
     });
     this._customRoute.q$
       .pipe(

--- a/ui/apps/ui/src/app/components/sort-by-functionality/sort-by-functionality.component.ts
+++ b/ui/apps/ui/src/app/components/sort-by-functionality/sort-by-functionality.component.ts
@@ -17,7 +17,7 @@ import { NavConfigsRepository } from '@collections/repositories/nav-configs.repo
 @Component({
   selector: 'ess-sort-by-functionality',
   template: ` <div class="col-sm-4 sort_container">
-    <div *ngIf="this.collection !== 'project'; else elseBlock">
+    <div *ngIf="this.collection !== 'project'">
       <label for="sorts" i18n>Sort By</label>
       <select
         [formControl]="selectedSortOptionControl"
@@ -36,7 +36,7 @@ import { NavConfigsRepository } from '@collections/repositories/nav-configs.repo
       </select>
     </div>
 
-    <ng-template #elseBlock>
+    <div *ngIf="this.collection === 'project'">
       <label for="sorts" i18n>Sort By</label>
       <select
         [formControl]="selectedSortOptionControl"
@@ -47,7 +47,7 @@ import { NavConfigsRepository } from '@collections/repositories/nav-configs.repo
         <option value="pdmr" i18n>Date - Most recent</option>
         <option value="pdlr" i18n>Date – Least recent</option>
       </select>
-    </ng-template>
+    </div>
   </div>`,
   styles: [
     `

--- a/ui/apps/ui/src/app/components/top-menu/top-menu.component.html
+++ b/ui/apps/ui/src/app/components/top-menu/top-menu.component.html
@@ -49,6 +49,31 @@
       <span class="ant-menu-item-custom">Providers</span>
     </a>
   </li>
+  <li nz-menu-item nzSelected="{{ this.selected === 'catalogue' }}">
+    <a
+      [queryParams]="{ q: '*' }"
+      [routerLink]="'/search/catalogue'"
+      [routerLinkActiveOptions]="{
+        queryParams: 'ignored',
+        paths: 'exact',
+        matrixParams: 'ignored',
+        fragment: 'ignored'
+      }"
+      routerLinkActive=""
+      [queryParams]="{
+        q: (q$ | async),
+        standard: (st$ | async),
+        tags: (tg$ | async),
+        exact: (ex$ | async),
+        radioValueAuthor: (radioValueAuthor$ | async),
+        radioValueExact: (radioValueExact$ | async),
+        radioValueTitle: (radioValueTitle$ | async),
+        radioValueKeyword: (radioValueKeyword$ | async)
+      }"
+    >
+      <span class="ant-menu-item-custom">Catalogues</span>
+    </a>
+  </li>
   <li *ngIf="showBetaCollections" nz-menu-item nzSelected="{{ this.selected === 'project' }}">
     <a
       [queryParams]="{ q: '*' }"

--- a/ui/apps/ui/src/styles.scss
+++ b/ui/apps/ui/src/styles.scss
@@ -769,6 +769,15 @@ h6 {
     }
   }
 
+  &.catalogue {
+    border-color: #91aad2;
+
+    .type-icon {
+      background-image: url('assets/icon-type-organisation.svg');
+    }
+  }
+
+
   &.software {
     border-color: #d291c0;
 


### PR DESCRIPTION
1. Catalogue collection is added as a tab in the top panel
2. redirection to all_catalogues with the chosen catalogue as a filter
3. redirection to mp for the detail view
4. search by abbreviation added also to provider, project and organisation collections