### PR TITLE
fix: [#1200] auto suggestion

### DIFF
--- a/backend/app/consts.py
+++ b/backend/app/consts.py
@@ -52,7 +52,6 @@ ALL_COLLECTION_LIST = [
     Collection.GUIDELINE,
     Collection.BUNDLE,
     Collection.OTHER_RP,
-    Collection.PROVIDER,
 ]
 
 

--- a/backend/tests/app/routes/test_suggestions.py
+++ b/backend/tests/app/routes/test_suggestions.py
@@ -61,7 +61,7 @@ async def test_suggestions_dispatch_collections(
         json={},
     )
     assert res.status_code == status.HTTP_200_OK
-    assert mock_post_search.call_count == 10
+    assert mock_post_search.call_count == 9
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #1200 

- auto-suggestion didn't work only in `all_collection` 
- that was the case because we were performing exactly the same search for each data type (collection) **including** new collection: `organisation` 
- we cannot perform a standard search (`title^100 author_names_tg^120 description^10 keywords_tg^10 tag_list_tg^10`) on an organisation collection that doesn't have those properties.


Scope:
- [x] fix auto suggestions in all_collection
- [x] remove auto suggestions for providers in all_collection