### PR TITLE
fix: reset adv serach query params for some collections

### DIFF
--- a/ui/apps/ui/src/app/components/search-input/search-input.component.html
+++ b/ui/apps/ui/src/app/components/search-input/search-input.component.html
@@ -35,7 +35,7 @@
         </div>
         <select
           *ngIf="!this.isSpecialCollection"
-          class="form-select"
+          class="form-select" 
           (click)="focused = false"
           [formControl]="collectionFc"
         >
@@ -498,12 +498,7 @@
       </div>
       <span
         class="adv-search-text-btn"
-        (click)="
-          standardSearch = true;
-          tags = [];
-          clearQueryAdv();
-          updateQueryParamsAdv(this.formControl.value || '*')
-        "
+        (click)="this.backToStandard()"
         ><- Go back to Basic Search</span
       >
       <span class="adv-search-text-btn" style="margin-left: 25px">

--- a/ui/apps/ui/src/app/components/search-input/search-input.component.ts
+++ b/ui/apps/ui/src/app/components/search-input/search-input.component.ts
@@ -233,6 +233,18 @@ export class SearchInputComponent implements OnInit {
     return false;
   }
 
+  resetAdvSearch() {
+    this.tags = [];
+    this.clearQueryAdv();
+    this.updateQueryParamsAdv(this.formControl.value || '*');
+    this.collectionFcAdvForm.setValue(this.collectionFcAdv[2]);
+  }
+
+  backToStandard() {
+    this.standardSearch = true;
+    this.resetAdvSearch();
+  }
+
   // TODO: stream event - off when search is not focused and what with suggestes result set on []
   @HostListener('document:click')
   clicked() {
@@ -265,6 +277,11 @@ export class SearchInputComponent implements OnInit {
         'catalogue',
       ];
       this.isAdvancedSearchOff = advSearchExcludeCollections.includes(val);
+      if (this.isAdvancedSearchOff) {
+        this.backToStandard();
+      } else {
+        this.resetAdvSearch();
+      }
     });
     this._customRoute.q$
       .pipe(


### PR DESCRIPTION
The ticket solves 2 bugs related to the fact, that advance search query params persisted after collection change even if those params are collection specific.
After change, the adv search form if opened in one tab should stay displayed for collections where it's relevant (excluding catalogues, projects and organisations), but in it's default option
@aleksandrahojszyk please confirm that the solution is in line with ui/ux expectations