### PR TITLE
show resources link mod

### DIFF
--- a/ui/apps/ui/src/app/components/results-with-pagination/result-ui-controls/show-related-resources.scss
+++ b/ui/apps/ui/src/app/components/results-with-pagination/result-ui-controls/show-related-resources.scss
@@ -1,7 +1,3 @@
-:host {
-  display: block;
-  margin-top: 4px;
-}
 
 .show-projects-icon {
   width: 18px;

--- a/ui/apps/ui/src/app/layouts/share/share.component.scss
+++ b/ui/apps/ui/src/app/layouts/share/share.component.scss
@@ -12,7 +12,6 @@
 
 .share-label {
   color: #040f81;
-  font-family: Inter;
   font-size: 14px;
   font-style: normal;
   font-weight: 500;

--- a/ui/apps/ui/src/styles.scss
+++ b/ui/apps/ui/src/styles.scss
@@ -599,7 +599,7 @@ h6 {
 
 .bottom-actions {
   border-top: 1px dotted #d9dee2;
-  padding-top: 10px;
+  padding-top: 14px;
 
   .sources-box {
     a {


### PR DESCRIPTION
Fix for "Show resources" link in bottom line:

![image](https://github.com/cyfronet-fid/eosc-search-service/assets/8420566/a076ba54-ae32-48ca-a706-e563dc56d5d0)
