### PR TITLE
fix: [#1420] handle services without pid

### DIFF
--- a/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
@@ -53,7 +53,7 @@ const urlAdapter = (
     case 'data source':
       return getDataSourceUrl(data?.pid);
     case 'service':
-      return `${ConfigService.config?.marketplace_url}/services/${data?.pid}`;
+      return `${ConfigService.config?.marketplace_url}/services/${data?.slug}`;
     case 'training':
       return '/trainings/' + data.id;
     case 'interoperability guideline':
@@ -83,8 +83,8 @@ const orderUrlAdapter = (
     case 'data source':
       return getServiceOrderUrl(data?.pid);
     case 'service':
-      return data.pid
-        ? `${ConfigService.config?.marketplace_url}/services/${data.pid}/offers`
+      return data.slug
+        ? `${ConfigService.config?.marketplace_url}/services/${data.slug}/offers`
         : undefined;
     case 'bundle':
       return `${ConfigService.config?.marketplace_url}/services/${data.service_id}/offers`;

--- a/ui/apps/ui/src/app/collections/data/services/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/services/adapter.data.ts
@@ -15,11 +15,11 @@ import {
 } from '@collections/data/utils';
 import { ConfigService } from '../../../services/config.service';
 
-export const getServiceOrderUrl = (pid?: string) => {
-  if (!pid) {
-    pid = '';
+export const getServiceOrderUrl = (slug?: string) => {
+  if (!slug) {
+    slug = '';
   }
-  return `${ConfigService.config?.marketplace_url}/services/${pid}/offers`;
+  return `${ConfigService.config?.marketplace_url}/services/${slug}/offers`;
 };
 
 const setType = (type: string | undefined) => {
@@ -49,10 +49,10 @@ export const servicesAdapter: IAdapter = {
     languages: transformLanguages(service?.language),
     horizontal: service?.horizontal,
     type: setType(service.type),
-    url: service.pid
-      ? `${ConfigService.config?.marketplace_url}/services/${service.pid}`
+    url: service.slug
+      ? `${ConfigService.config?.marketplace_url}/services/${service.slug}`
       : '',
-    orderUrl: getServiceOrderUrl(service.pid),
+    orderUrl: getServiceOrderUrl(service.slug),
     collection: COLLECTION,
     coloredTags: [],
     tags: [

--- a/ui/apps/ui/src/app/collections/data/services/service.model.ts
+++ b/ui/apps/ui/src/app/collections/data/services/service.model.ts
@@ -7,6 +7,7 @@ export interface IService {
   scientific_domains: string[];
   resource_organisation: string;
   pid: string;
+  slug: string;
   best_access_right: string;
   type: string;
   usage_counts_views: string;

--- a/ui/apps/ui/src/app/pages/search-page/search-page.component.html
+++ b/ui/apps/ui/src/app/pages/search-page/search-page.component.html
@@ -80,7 +80,7 @@
           <h4>Initiatives</h4>
 
           <a href="#" class="right-column-link">
-            <div class="right-link-title">Organisations</div>
+            <div class="right-link-title">Providers</div>
             <div class="right-link-desc">Browse entities providing resources to our service.</div>
             <div class="right-link-arrow"><img src="assets/arrow-right-dark.svg" alt="more" /></div>
           </a>


### PR DESCRIPTION
closes #1420 

scope:
- [x] fixes redirects to the MP for services added directly in MP (without pid) - redirect is based on a slug. Scope: all collection, services
- [x] organisations -> providers
