### PR TITLE
feat: [#1438] mp redirects

### DIFF
--- a/backend/app/routes/web/configuration.py
+++ b/backend/app/routes/web/configuration.py
@@ -12,7 +12,8 @@ router = APIRouter()
 @router.get("/config", name="web:configuration", response_model=ConfigurationResponse)
 async def config():
     return ConfigurationResponse(
-        marketplace_url=settings.MARKETPLACE_BASE_URL,
+        eu_marketplace_url=settings.EU_MARKETPLACE_BASE_URL,
+        pl_marketplace_url=settings.PL_MARKETPLACE_BASE_URL,
         eosc_explore_url=settings.EOSC_EXPLORE_URL,
         eosc_commons_url=settings.EOSC_COMMONS_URL,
         eosc_commons_env=settings.EOSC_COMMONS_ENV,

--- a/backend/app/schemas/configuration_response.py
+++ b/backend/app/schemas/configuration_response.py
@@ -5,7 +5,8 @@ from app.settings import Url
 
 
 class ConfigurationResponse(BaseModel):
-    marketplace_url: Url
+    eu_marketplace_url: Url
+    pl_marketplace_url: Url
     eosc_commons_url: Url
     eosc_commons_env: str
     eosc_explore_url: Url

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -77,7 +77,8 @@ class GlobalSettings(BaseSettings):
     )
 
     # Redirections
-    MARKETPLACE_BASE_URL: Url = "https://marketplace.eosc-portal.eu/"
+    EU_MARKETPLACE_BASE_URL: Url = "https://marketplace.sandbox.eosc-beyond.eu/"
+    PL_MARKETPLACE_BASE_URL: Url = "https://marketplace.eosc.pl/"
     EOSC_COMMONS_URL: Url = (  # Without / at the end it doesn't work
         "https://s3.cloud.cyfronet.pl/eosc-portal-common/"
     )

--- a/backend/tests/app/routes/test_configuration.py
+++ b/backend/tests/app/routes/test_configuration.py
@@ -13,7 +13,8 @@ async def test_return_backend_config(app: FastAPI, client: AsyncClient) -> None:
     assert response.json() == {
         "eosc_commons_env": "production",
         "eosc_commons_url": "https://s3.cloud.cyfronet.pl/eosc-portal-common/",
-        "marketplace_url": "https://marketplace.eosc-portal.eu/",
+        "eu_marketplace_url": "https://marketplace.sandbox.eosc-beyond.eu/",
+        "pl_marketplace_url": "https://marketplace.eosc.pl/",
         "eosc_explore_url": "https://explore.eosc-portal.eu/",
         "knowledge_hub_url": "https://knowledge-hub.eosc-portal.eu/",
         "is_sort_by_relevance": True,

--- a/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
@@ -11,8 +11,6 @@ import { IDataSource } from '@collections/data/data-sources/data-source.model';
 import { ITraining } from '@collections/data/trainings/training.model';
 import { IGuideline } from '@collections/data/guidelines/guideline.model';
 import { IService } from '@collections/data/services/service.model';
-import { getDataSourceUrl } from '@collections/data/data-sources/adapter.data';
-import { getServiceOrderUrl } from '../services/adapter.data';
 import {
   toArray,
   toValueWithLabel,
@@ -51,23 +49,25 @@ export const redirectUrlAdapter = (
         ConfigService.config?.eosc_explore_url
       }/search/result?id=${data?.id?.split('|')?.pop()}`;
     case 'data source':
-      return getDataSourceUrl(data?.pid);
+      return data?.pid
+        ? `${ConfigService.config?.eu_marketplace_url}/services/${data.pid}`
+        : '';
     case 'service':
-      return `${ConfigService.config?.marketplace_url}/services/${data?.slug}/offers`;
+      return `${ConfigService.config?.eu_marketplace_url}/services/${data?.slug}`;
     case 'training':
       return '/trainings/' + data.id;
     case 'interoperability guideline':
       return '/guidelines/' + data.id;
     case 'bundle':
-      return `${ConfigService.config?.marketplace_url}/services/${data.service_id}`;
+      return `${ConfigService.config?.eu_marketplace_url}/services/${data.service_id}`;
     case 'provider':
-      return `${ConfigService.config?.marketplace_url}/providers/${data?.pid}`;
+      return `${ConfigService.config?.eu_marketplace_url}/providers/${data?.pid}`;
     default:
       return '';
   }
 };
 
-const logoUrlAdapter = (
+export const logoUrlAdapter = (
   type: string,
   data: Partial<
     IOpenAIREResult &
@@ -82,18 +82,18 @@ const logoUrlAdapter = (
   switch (type) {
     case 'data source':
       return data.pid
-        ? `${ConfigService.config?.marketplace_url}/services/${data.pid}/logo`
-        : undefined;
+        ? `${ConfigService.config?.eu_marketplace_url}/services/${data.pid}/logo`
+        : '';
     case 'service':
       return data.slug
-        ? `${ConfigService.config?.marketplace_url}/services/${data.slug}/logo`
-        : undefined;
+        ? `${ConfigService.config?.eu_marketplace_url}/services/${data.slug}/logo`
+        : '';
     default:
-      return undefined;
+      return '';
   }
 };
 
-const orderUrlAdapter = (
+export const orderUrlAdapter = (
   type: string,
   data: Partial<
     IOpenAIREResult &
@@ -107,15 +107,17 @@ const orderUrlAdapter = (
 ) => {
   switch (type) {
     case 'data source':
-      return getServiceOrderUrl(data?.pid);
+      return data.pid
+        ? `${ConfigService.config?.eu_marketplace_url}/services/${data.pid}/offers`
+        : '';
     case 'service':
       return data.slug
-        ? `${ConfigService.config?.marketplace_url}/services/${data.slug}/offers`
-        : undefined;
+        ? `${ConfigService.config?.eu_marketplace_url}/services/${data.slug}/offers`
+        : '';
     case 'bundle':
-      return `${ConfigService.config?.marketplace_url}/services/${data.service_id}/offers`;
+      return `${ConfigService.config?.eu_marketplace_url}/services/${data.service_id}/offers`;
     default:
-      return undefined;
+      return '';
   }
 };
 

--- a/ui/apps/ui/src/app/collections/data/bundles/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/bundles/adapter.data.ts
@@ -15,9 +15,9 @@ import {
 
 function getBundleUrl(bundle: Partial<IBundle> & { id: string }): string {
   if (bundle.iid != null && bundle.iid.length === 1) {
-    return `${ConfigService.config?.marketplace_url}/services/${bundle.service_id}/bundles/${bundle.iid?.[0]}`;
+    return `${ConfigService.config?.eu_marketplace_url}/services/${bundle.service_id}/bundles/${bundle.iid?.[0]}`;
   }
-  return `${ConfigService.config?.marketplace_url}/services/${bundle.service_id}`;
+  return `${ConfigService.config?.eu_marketplace_url}/services/${bundle.service_id}`;
 }
 
 export const bundlesAdapter: IAdapter = {
@@ -35,7 +35,7 @@ export const bundlesAdapter: IAdapter = {
     },
     collection: COLLECTION,
     redirectUrl: getBundleUrl(bundle),
-    orderUrl: `${ConfigService.config?.marketplace_url}/services/${bundle.service_id}/offers`,
+    orderUrl: `${ConfigService.config?.eu_marketplace_url}/services/${bundle.service_id}/offers`,
     coloredTags: [],
     tags: [
       {

--- a/ui/apps/ui/src/app/collections/data/catalogues/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/catalogues/adapter.data.ts
@@ -43,7 +43,7 @@ export const cataloguesAdapter: IAdapter = {
     ],
 
     redirectUrl: catalogue.pid
-      ? `${ConfigService.config?.marketplace_url}/catalogues/${catalogue.pid}`
+      ? `${ConfigService.config?.eu_marketplace_url}/catalogues/${catalogue.pid}`
       : '',
     coloredTags: [],
     isResearchProduct: false,

--- a/ui/apps/ui/src/app/collections/data/data-sources/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/data-sources/adapter.data.ts
@@ -13,14 +13,6 @@ import {
   toKeywordsSecondaryTag,
 } from '@collections/data/utils';
 import { ConfigService } from '../../../services/config.service';
-import { getServiceOrderUrl } from '../services/adapter.data';
-
-export const getDataSourceUrl = (pid?: string) => {
-  if (!pid) {
-    pid = '';
-  }
-  return `${ConfigService.config?.marketplace_url}/services/${pid}/offers`;
-};
 
 export const dataSourcesAdapter: IAdapter = {
   id: URL_PARAM_NAME,
@@ -36,11 +28,15 @@ export const dataSourcesAdapter: IAdapter = {
       label: dataSource.type || '',
       value: (dataSource.type || '')?.replace(/ +/gm, '-'),
     },
-    redirectUrl: getDataSourceUrl(dataSource.pid),
-    logoUrl: dataSource.pid
-      ? `${ConfigService.config?.marketplace_url}/services/${dataSource.pid}/logo`
+    redirectUrl: dataSource.pid
+      ? `${ConfigService.config?.eu_marketplace_url}/services/${dataSource.pid}`
       : '',
-    orderUrl: getServiceOrderUrl(dataSource.pid),
+    logoUrl: dataSource.pid
+      ? `${ConfigService.config?.eu_marketplace_url}/services/${dataSource.pid}/logo`
+      : '',
+    orderUrl: dataSource.pid
+      ? `${ConfigService.config?.eu_marketplace_url}/services/${dataSource.pid}/offers`
+      : '',
     collection: COLLECTION,
     coloredTags: [],
     tags: [

--- a/ui/apps/ui/src/app/collections/data/index.ts
+++ b/ui/apps/ui/src/app/collections/data/index.ts
@@ -40,6 +40,9 @@ import { cataloguesAdapter } from './catalogues/adapter.data';
 
 import { plDatasetsAdapter } from '../pl-data/datasets/adapter.data';
 import { plAllCollectionsAdapter } from '../pl-data/all/adapter.data';
+import { plProvidersAdapter } from '../pl-data/providers/adapter.data';
+import { plServicesAdapter } from '../pl-data/services/adapter.data';
+import { plDataSourcesAdapter } from '../pl-data/data-sources/adapter.data';
 
 import { trainingsSearchMetadata } from './trainings/search-metadata.data';
 import { guidelinesSearchMetadata } from './guidelines/search-metadata.data';
@@ -110,9 +113,9 @@ export const PL_ADAPTERS: IAdapter[] = [
   plAllCollectionsAdapter,
   publicationsAdapter,
   plDatasetsAdapter,
-  servicesAdapter,
-  dataSourcesAdapter,
-  providersAdapter,
+  plServicesAdapter,
+  plDataSourcesAdapter,
+  plProvidersAdapter,
 ];
 
 export const FILTERS: IFiltersConfig[] = [

--- a/ui/apps/ui/src/app/collections/data/providers/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/providers/adapter.data.ts
@@ -30,6 +30,12 @@ export const providersAdapter: IAdapter = {
       label: 'provider',
       value: 'provider',
     },
+    redirectUrl: provider.pid
+      ? `${ConfigService.config?.eu_marketplace_url}/providers/${provider.pid}`
+      : '',
+    logoUrl: provider.pid
+      ? `${ConfigService.config?.eu_marketplace_url}/providers/${provider.pid}/logo`
+      : '',
     collection: COLLECTION,
     coloredTags: [],
     secondaryTags: [
@@ -59,9 +65,6 @@ export const providersAdapter: IAdapter = {
         filter: 'meril_scientific_domains',
       },
     ],
-    redirectUrl: provider.pid
-      ? `${ConfigService.config?.marketplace_url}/providers/${provider.pid}`
-      : '',
     ...parseStatistics(provider),
   }),
 };

--- a/ui/apps/ui/src/app/collections/data/services/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/services/adapter.data.ts
@@ -15,13 +15,6 @@ import {
 } from '@collections/data/utils';
 import { ConfigService } from '../../../services/config.service';
 
-export const getServiceOrderUrl = (slug?: string) => {
-  if (!slug) {
-    slug = '';
-  }
-  return `${ConfigService.config?.marketplace_url}/services/${slug}/offers`;
-};
-
 const setType = (type: string | undefined) => {
   if (type === 'data source') {
     return {
@@ -50,12 +43,14 @@ export const servicesAdapter: IAdapter = {
     horizontal: service?.horizontal,
     type: setType(service.type),
     redirectUrl: service.slug
-      ? `${ConfigService.config?.marketplace_url}/services/${service.slug}/offers`
+      ? `${ConfigService.config?.eu_marketplace_url}/services/${service.slug}`
       : '',
     logoUrl: service.slug
-      ? `${ConfigService.config?.marketplace_url}/services/${service.slug}/logo`
+      ? `${ConfigService.config?.eu_marketplace_url}/services/${service.slug}/logo`
       : '',
-    orderUrl: getServiceOrderUrl(service.slug),
+    orderUrl: service.slug
+      ? `${ConfigService.config?.eu_marketplace_url}/services/${service.slug}/offers`
+      : '',
     collection: COLLECTION,
     coloredTags: [],
     tags: [

--- a/ui/apps/ui/src/app/collections/pl-data/all/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/pl-data/all/adapter.data.ts
@@ -7,8 +7,11 @@ import { IProvider } from '../../data/providers/provider.model';
 import { IOpenAIREResult } from '../../data/openair.model';
 import {
   allCollectionsAdapter,
+  logoUrlAdapter,
+  orderUrlAdapter,
   redirectUrlAdapter,
 } from '../../data/all/adapter.data';
+import { ConfigService } from '../../../services/config.service';
 
 const plRedirectUrlAdapter = (
   type: string,
@@ -22,12 +25,77 @@ const plRedirectUrlAdapter = (
       IProvider
   >
 ) => {
-  if (type === 'dataset') {
-    return data?.url?.[0] || '';
-  }
+  switch (type) {
+    case 'dataset':
+      return data?.url?.[0] || '';
 
-  // Use the original redirectUrlAdapter for all other cases
-  return redirectUrlAdapter(type, data);
+    case 'service':
+      return data?.slug
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${data.slug}/offers`
+        : '';
+
+    case 'data source':
+      return data?.pid
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${data.pid}/offers`
+        : '';
+
+    default:
+      // Use the original redirectUrlAdapter for all other cases
+      return redirectUrlAdapter(type, data);
+  }
+};
+
+const plLogoUrlAdapter = (
+  type: string,
+  data: Partial<
+    IOpenAIREResult &
+      IDataSource &
+      IService &
+      ITraining &
+      IGuideline &
+      IBundle &
+      IProvider
+  >
+) => {
+  switch (type) {
+    case 'data source':
+      return data.pid
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${data.pid}/logo`
+        : '';
+    case 'service':
+      return data.slug
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${data.slug}/logo`
+        : '';
+    default:
+      // Use the original redirectUrlAdapter for all other cases
+      return logoUrlAdapter(type, data);
+  }
+};
+
+export const plOrderUrlAdapter = (
+  type: string,
+  data: Partial<
+    IOpenAIREResult &
+      IDataSource &
+      IService &
+      ITraining &
+      IGuideline &
+      IBundle &
+      IProvider
+  >
+) => {
+  switch (type) {
+    case 'data source':
+      return data.pid
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${data.pid}/offers`
+        : '';
+    case 'service':
+      return data.slug
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${data.slug}/offers`
+        : '';
+    default:
+      return orderUrlAdapter(type, data);
+  }
 };
 
 export const plAllCollectionsAdapter = {
@@ -50,6 +118,8 @@ export const plAllCollectionsAdapter = {
     return {
       ...result,
       redirectUrl: plRedirectUrlAdapter(data.type || '', data), // Override the redirectUrl
+      logoUrl: plLogoUrlAdapter(data.type || '', data),
+      orderUrl: plOrderUrlAdapter(data.type || '', data),
     };
   },
 };

--- a/ui/apps/ui/src/app/collections/pl-data/data-sources/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/pl-data/data-sources/adapter.data.ts
@@ -1,0 +1,22 @@
+import { ConfigService } from '../../../services/config.service';
+import { IDataSource } from '../../data/data-sources/data-source.model';
+import { dataSourcesAdapter } from '../../data/data-sources/adapter.data';
+
+export const plDataSourcesAdapter = {
+  ...dataSourcesAdapter,
+  adapter: (dataSource: Partial<IDataSource> & { id: string }) => {
+    const result = dataSourcesAdapter.adapter(dataSource);
+    return {
+      ...result,
+      redirectUrl: dataSource.pid
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${dataSource.pid}/offers`
+        : '',
+      logoUrl: dataSource.pid
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${dataSource.pid}/logo`
+        : '',
+      orderUrl: dataSource.pid
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${dataSource.pid}/offers`
+        : '',
+    };
+  },
+};

--- a/ui/apps/ui/src/app/collections/pl-data/providers/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/pl-data/providers/adapter.data.ts
@@ -1,0 +1,19 @@
+import { providersAdapter } from '../../data/providers/adapter.data';
+import { IProvider } from '../../data/providers/provider.model';
+import { ConfigService } from '../../../services/config.service';
+
+export const plProvidersAdapter = {
+  ...providersAdapter,
+  adapter: (provider: Partial<IProvider> & { id: string }) => {
+    const result = providersAdapter.adapter(provider);
+    return {
+      ...result,
+      redirectUrl: provider.pid
+        ? `${ConfigService.config?.pl_marketplace_url}/providers/${provider.pid}`
+        : '',
+      logoUrl: provider.pid
+        ? `${ConfigService.config?.pl_marketplace_url}/providers/${provider.pid}/logo`
+        : '',
+    };
+  },
+};

--- a/ui/apps/ui/src/app/collections/pl-data/services/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/pl-data/services/adapter.data.ts
@@ -1,0 +1,23 @@
+import { ConfigService } from '../../../services/config.service';
+import { servicesAdapter } from '../../data/services/adapter.data';
+import { IService } from '../../data/services/service.model';
+import { IDataSource } from '../../data/data-sources/data-source.model';
+
+export const plServicesAdapter = {
+  ...servicesAdapter,
+  adapter: (service: Partial<IService & IDataSource> & { id: string }) => {
+    const result = servicesAdapter.adapter(service);
+    return {
+      ...result,
+      redirectUrl: service.slug
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${service.slug}/offers`
+        : '',
+      logoUrl: service.slug
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${service.slug}/logo`
+        : '',
+      orderUrl: service.slug
+        ? `${ConfigService.config?.pl_marketplace_url}/services/${service.slug}/offers`
+        : '',
+    };
+  },
+};

--- a/ui/apps/ui/src/app/components/results-with-pagination/result-ui-controls/pin.component.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/result-ui-controls/pin.component.ts
@@ -64,7 +64,7 @@ export class PinComponent implements OnChanges {
       const type =
         this.resourceType === 'other' ? 'other_rp' : this.resourceType;
       this.pinUrl = `${
-        this._configService.get().marketplace_url
+        this._configService.get().eu_marketplace_url
       }/research_products/new?resource_id=${encodeURIComponent(
         this.resourceId
       )}&resource_type=${encodeURIComponent(type)}`;

--- a/ui/apps/ui/src/app/components/results-with-pagination/result.component.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/result.component.ts
@@ -378,7 +378,7 @@ export class ResultComponent implements OnInit {
 
   getLogoUrl(slug: string | undefined) {
     return slug
-      ? `${ConfigService.config?.marketplace_url}/services/${slug}/logo`
+      ? `${ConfigService.config?.eu_marketplace_url}/services/${slug}/logo`
       : 'assets/bundle_service.svg';
   }
 

--- a/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.ts
@@ -93,7 +93,7 @@ export class ResultsWithPaginationComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.marketplaceUrl = this._configService.get().marketplace_url;
+    this.marketplaceUrl = this._configService.get().eu_marketplace_url;
     this.pageNr$
       .pipe(
         untilDestroyed(this),

--- a/ui/apps/ui/src/app/layouts/ig-services-card/ig-services-card.component.ts
+++ b/ui/apps/ui/src/app/layouts/ig-services-card/ig-services-card.component.ts
@@ -14,7 +14,7 @@ export class IgServicesCardComponent {
   @Input() title = '';
 
   openService(pid: string) {
-    const url = `${ConfigService.config?.marketplace_url}/services/${pid}`;
+    const url = `${ConfigService.config?.eu_marketplace_url}/services/${pid}`;
     window.open(url);
   }
   showAll(): void {

--- a/ui/apps/ui/src/app/layouts/ig-services-card/ig-services-detail-card.component.ts
+++ b/ui/apps/ui/src/app/layouts/ig-services-card/ig-services-detail-card.component.ts
@@ -31,7 +31,7 @@ export class IgServicesDetailCardComponent {
   }
 
   openService(pid: string) {
-    const url = `${ConfigService.config?.marketplace_url}/services/${pid}`;
+    const url = `${ConfigService.config?.eu_marketplace_url}/services/${pid}`;
     window.open(url);
   }
 

--- a/ui/apps/ui/src/app/pages/guidelines-page/guideline-detail-page.component.ts
+++ b/ui/apps/ui/src/app/pages/guidelines-page/guideline-detail-page.component.ts
@@ -27,7 +27,7 @@ export class GuidelineDetailPageComponent implements OnInit {
 
   type = DICTIONARY_TYPE_FOR_PIPE;
 
-  marketplaceUrl: string = ConfigService.config?.marketplace_url;
+  marketplaceUrl: string = ConfigService.config?.eu_marketplace_url;
   currentUrl: string = this._router.url;
 
   constructor(

--- a/ui/apps/ui/src/app/pages/search-page/search-page.component.ts
+++ b/ui/apps/ui/src/app/pages/search-page/search-page.component.ts
@@ -80,7 +80,7 @@ export class SearchPageComponent implements OnInit {
   public clearAll = false;
   isSpecialCollection = false;
   knowledgeHubUrl = this._configService.get().knowledge_hub_url;
-  marketplaceUrl = this._configService.get().marketplace_url;
+  marketplaceUrl = this._configService.get().eu_marketplace_url;
 
   constructor(
     private _customRoute: CustomRoute,

--- a/ui/apps/ui/src/app/services/config.service.ts
+++ b/ui/apps/ui/src/app/services/config.service.ts
@@ -7,7 +7,8 @@ import { WINDOW } from '../app.providers';
 import { EoscCommonWindow } from '@components/main-header/types';
 
 export interface BackendConfig {
-  marketplace_url: string;
+  eu_marketplace_url: string;
+  pl_marketplace_url: string;
   eosc_commons_url: string;
   eosc_commons_env: string;
   eosc_explore_url: string;


### PR DESCRIPTION
closes #1438 

Scope:
- [x] `EU_MARKETPLACE_BASE_URL`, `PL_MARKETPLACE_BASE_URL`
- [x] EU redirects to sandbox
- [x] PL redirects to marketplace.eosc.pl 
- [x] redirectUrl, logoUrl, orderUrl for: all collection services, data source, providers, bundles, offers, catalogues 
- [x] without /offers in EU scope for services and data sources - PR is missing 