### PR TITLE
fix: [#1618] simplify oidc defaults

### DIFF
--- a/.github/workflows/backend-styles.yml
+++ b/.github/workflows/backend-styles.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Check with black
       run: |
         pipenv run black --version
-        pipenv run black --check --preview alembic app tests
+        pipenv run black --check alembic app tests
       working-directory: ./backend
     - name: Check with isort
       run: |

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -59,13 +59,12 @@ class GlobalSettings(BaseSettings):
     OIDC_HOST: Url = "https://core-proxy.sandbox.eosc-beyond.eu"
     OIDC_CLIENT_ID: str = "NO_CLIENT_ID"
     OIDC_CLIENT_SECRET: str = "NO_CLIENT_SECRET"
-    OIDC_AAI_NEW_API: bool = False
-    # Old OIDC API by default
-    OIDC_ISSUER: Url = urljoin(OIDC_HOST, "/oidc/")
-    OIDC_AUTH_ENDPOINT: str = "/oidc/authorize"
-    OIDC_TOKEN_ENDPOINT: str = "/oidc/token"
-    OIDC_USERINFO_ENDPOINT: str = "/oidc/userinfo"
-    OIDC_JWKS_ENDPOINT: str = "/oidc/jwk"
+
+    OIDC_ISSUER: Url = urljoin(OIDC_HOST, "/auth/realms/core")
+    OIDC_AUTH_ENDPOINT: str = "/auth/realms/core/protocol/openid-connect/auth"
+    OIDC_TOKEN_ENDPOINT: str = "/auth/realms/core/protocol/openid-connect/token"
+    OIDC_USERINFO_ENDPOINT: str = "/auth/realms/core/protocol/openid-connect/userinfo"
+    OIDC_JWKS_ENDPOINT: str = "/auth/realms/core/protocol/openid-connect/certs"
 
     # - Sentry
     SENTRY_DSN: Optional[str] = None
@@ -121,15 +120,6 @@ class EnvironmentConfig(GlobalSettings):
     def make_settings(self) -> GlobalSettings:
         """Make and return final settings"""
         s = self.TYPES_TO_SETTINGS_MAP[self.ENVIRONMENT]()
-        if s.OIDC_AAI_NEW_API:  # Adjust OIDC integration params for the new API
-            s.OIDC_ISSUER = urljoin(s.OIDC_HOST, "/auth/realms/core")
-            s.OIDC_JWKS_ENDPOINT = "/auth/realms/core/protocol/openid-connect/certs"
-            s.OIDC_USERINFO_ENDPOINT = (
-                "/auth/realms/core/protocol/openid-connect/userinfo"
-            )
-            s.OIDC_TOKEN_ENDPOINT = "/auth/realms/core/protocol/openid-connect/token"
-            s.OIDC_AUTH_ENDPOINT = "/auth/realms/core/protocol/openid-connect/auth"
-
         return s
 
 

--- a/ui/apps/ui/src/app/pages/adapters-page/adapter-detail-page.component.ts
+++ b/ui/apps/ui/src/app/pages/adapters-page/adapter-detail-page.component.ts
@@ -3,13 +3,12 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { AdaptersService } from '@pages/adapters-page/adapters.service';
 import { IResult } from '@collections/repositories/types';
-import { catchError, map, switchMap } from 'rxjs';
-import { Observable, of } from 'rxjs';
+import { map, switchMap } from 'rxjs';
 import { adaptersAdapter } from '@collections/data/adapters/adapter.data';
 import { DICTIONARY_TYPE_FOR_PIPE } from '../../dictionary/dictionaryType';
 import { RedirectService } from '@collections/services/redirect.service';
 import { HttpClient } from '@angular/common/http';
-import { ALLOWED_EXTENSIONS, FALLBACK_LOGO, MAX_IMAGE_SIZE } from './config';
+import { ALLOWED_EXTENSIONS, FALLBACK_LOGO } from './config';
 
 @UntilDestroy()
 @Component({


### PR DESCRIPTION
closes #1618 

@wziajka should we set those values for dev instance? On localhost when try to log in, it says "client not found"