### PR TITLE
Fix: [#1645] use pid or slug

### DIFF
--- a/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
@@ -11,6 +11,7 @@ import { IDataSource } from '@collections/data/data-sources/data-source.model';
 import { ITraining } from '@collections/data/trainings/training.model';
 import { IGuideline } from '@collections/data/guidelines/guideline.model';
 import { IService } from '@collections/data/services/service.model';
+import { IAdapterModel } from '@collections/data/adapters/adapter.model';
 import {
   toArray,
   toValueWithLabel,
@@ -47,7 +48,8 @@ const extractDate = (
       ITraining &
       IGuideline &
       IBundle &
-      IProvider
+      IProvider &
+      IAdapterModel
   >
 ) => {
   switch (data.type) {
@@ -59,6 +61,7 @@ const extractDate = (
     case 'software':
     case 'dataset':
     case 'training':
+    case 'adapter':
     case 'other':
       return formatPublicationDate(data['publication_date']);
     default:
@@ -74,7 +77,8 @@ const setIsResearchProduct = (
       ITraining &
       IGuideline &
       IBundle &
-      IProvider
+      IProvider &
+      IAdapterModel
   >
 ) => {
   switch (data.type) {
@@ -98,7 +102,8 @@ export const allCollectionsAdapter: IAdapter = {
         IService &
         IGuideline &
         IBundle &
-        IProvider
+        IProvider &
+        IAdapterModel
     > & {
       id: string;
     }

--- a/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/all/adapter.data.ts
@@ -24,112 +24,13 @@ import {
   parseStatistics,
   toKeywordsSecondaryTag,
 } from '@collections/data/utils';
-import { ConfigService } from '../../../services/config.service';
 import { IBundle } from '@collections/data/bundles/bundle.model';
 import { IProvider } from '@collections/data/providers/provider.model';
-
-const urlAdapter = (
-  type: string,
-  data: Partial<
-    IOpenAIREResult &
-      IDataSource &
-      IService &
-      ITraining &
-      IGuideline &
-      IBundle &
-      IProvider
-  >
-) => {
-  switch (type) {
-    case 'dataset':
-    case 'publication':
-    case 'software':
-    case 'other':
-      return `${
-        ConfigService.config?.eosc_explore_url
-      }/search/result?id=${encodeURIComponent(
-        data.id?.split('|')?.pop() || ''
-      )}`;
-    case 'data source':
-    case 'service':
-      return `${
-        ConfigService.config?.marketplace_url
-      }/services/${encodeURIComponent(data.pid || '')}`;
-
-    case 'bundle':
-      return `${
-        ConfigService.config?.marketplace_url
-      }/services/${encodeURIComponent(data.service_id || '')}`;
-
-    case 'provider':
-      return `${
-        ConfigService.config?.marketplace_url
-      }/providers/${encodeURIComponent(data.pid || '')}`;
-
-    case 'training':
-      return '/trainings/' + encodeURIComponent(data.id || '');
-
-    case 'interoperability guideline':
-      return '/guidelines/' + encodeURIComponent(data.id || '');
-
-    default:
-      return '';
-  }
-};
-
-const logoUrlAdapter = (
-  type: string,
-  data: Partial<
-    IOpenAIREResult &
-      IDataSource &
-      IService &
-      ITraining &
-      IGuideline &
-      IBundle &
-      IProvider
-  >
-) => {
-  switch (type) {
-    case 'data source':
-    case 'service':
-      return `${
-        ConfigService.config?.marketplace_url
-      }/services/${encodeURIComponent(data.pid || '')}/logo`;
-    case 'provider':
-      return `${
-        ConfigService.config?.marketplace_url
-      }/providers/${encodeURIComponent(data?.pid || '')}/logo`;
-    default:
-      return undefined;
-  }
-};
-
-const orderUrlAdapter = (
-  type: string,
-  data: Partial<
-    IOpenAIREResult &
-      IDataSource &
-      IService &
-      ITraining &
-      IGuideline &
-      IBundle &
-      IProvider
-  >
-) => {
-  switch (type) {
-    case 'data source':
-    case 'service':
-      return `${
-        ConfigService.config?.marketplace_url
-      }/services/${encodeURIComponent(data.pid || '')}/offers`;
-    case 'bundle':
-      return `${
-        ConfigService.config?.marketplace_url
-      }/services/${encodeURIComponent(data.service_id || '')}/offers`;
-    default:
-      return undefined;
-  }
-};
+import {
+  getEntityLogoUrl,
+  getEntityOrderUrl,
+  getEntityUrl,
+} from '../url-builder-utils';
 
 const forInteroperabilityGuidelinesValueAdapter = (value: string = '') => {
   const valueToLowerCase = value.toLowerCase();
@@ -209,9 +110,9 @@ export const allCollectionsAdapter: IAdapter = {
     documentType: data?.document_type,
     date: extractDate(data),
     languages: transformLanguages(data?.language),
-    url: urlAdapter(data.type || '', data),
-    logoUrl: logoUrlAdapter(data.type || '', data),
-    orderUrl: orderUrlAdapter(data.type || '', data),
+    url: getEntityUrl(data.type || '', data),
+    logoUrl: getEntityLogoUrl(data.type || '', data),
+    orderUrl: getEntityOrderUrl(data.type || '', data),
     exportData: data.exportation || [],
     urls: data.url,
     horizontal: data?.horizontal,

--- a/ui/apps/ui/src/app/collections/data/catalogues/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/catalogues/adapter.data.ts
@@ -6,11 +6,8 @@ import {
   toArray,
   toValueWithLabel,
 } from '@collections/filters-serializers/utils';
-import { ConfigService } from '../../../services/config.service';
-import {
-  formatPublicationDate,
-  toKeywordsSecondaryTag,
-} from '@collections/data/utils';
+import { formatPublicationDate, toKeywordsSecondaryTag } from '../utils';
+import { buildCatalogueUrl } from '../url-builder-utils';
 
 export const cataloguesAdapter: IAdapter = {
   id: URL_PARAM_NAME,
@@ -47,13 +44,8 @@ export const cataloguesAdapter: IAdapter = {
     secondaryTags: [
       toKeywordsSecondaryTag(catalogue.keywords ?? [], 'keywords'),
     ],
-
-    url: `${
-      ConfigService.config?.marketplace_url
-    }/catalogues/${encodeURIComponent(catalogue.pid || '')}`,
-    logoUrl: `${
-      ConfigService.config?.marketplace_url
-    }/catalogues/${encodeURIComponent(catalogue.pid || '')}/logo`,
+    url: buildCatalogueUrl(catalogue),
+    logoUrl: buildCatalogueUrl(catalogue, '/logo'),
     coloredTags: [],
     isResearchProduct: false,
   }),

--- a/ui/apps/ui/src/app/collections/data/data-sources/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/data-sources/adapter.data.ts
@@ -6,13 +6,13 @@ import {
   toArray,
   toValueWithLabel,
 } from '@collections/filters-serializers/utils';
-import { transformLanguages } from '@collections/data/shared-tags';
+import { transformLanguages } from '../shared-tags';
 import {
   parseStatistics,
   toInterPatternsSecondaryTag,
   toKeywordsSecondaryTag,
-} from '@collections/data/utils';
-import { ConfigService } from '../../../services/config.service';
+} from '../utils';
+import { buildServiceUrl } from '../url-builder-utils';
 
 export const dataSourcesAdapter: IAdapter = {
   id: URL_PARAM_NAME,
@@ -28,15 +28,9 @@ export const dataSourcesAdapter: IAdapter = {
       label: dataSource.type || '',
       value: (dataSource.type || '')?.replace(/ +/gm, '-'),
     },
-    url: `${
-      ConfigService.config?.marketplace_url
-    }/services/${encodeURIComponent(dataSource.pid || '')}`,
-    logoUrl: `${
-      ConfigService.config?.marketplace_url
-    }/services/${encodeURIComponent(dataSource.pid || '')}/logo`,
-    orderUrl: `${
-      ConfigService.config?.marketplace_url
-    }/services/${encodeURIComponent(dataSource.pid || '')}/offers`,
+    url: buildServiceUrl(dataSource),
+    logoUrl: buildServiceUrl(dataSource, '/logo'),
+    orderUrl: buildServiceUrl(dataSource, '/offers'),
     collection: COLLECTION,
     coloredTags: [],
     tags: [

--- a/ui/apps/ui/src/app/collections/data/providers/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/providers/adapter.data.ts
@@ -1,14 +1,14 @@
 import { IAdapter, IResult } from '../../repositories/types';
 import { URL_PARAM_NAME } from './nav-config.data';
 import { COLLECTION } from './search-metadata.data';
-import { IProvider } from '@collections/data/providers/provider.model';
-import { parseStatistics } from '@collections/data/utils';
+import { IProvider } from './provider.model';
+import { parseStatistics } from '../utils';
 import {
   toArray,
   toValueWithLabel,
 } from '@collections/filters-serializers/utils';
-import { ConfigService } from '../../../services/config.service';
-import { toKeywordsSecondaryTag } from '@collections/data/utils';
+import { toKeywordsSecondaryTag } from '../utils';
+import { buildProviderUrl } from '../url-builder-utils';
 
 const getDescription = (desc: string[]) => {
   return desc.join('');
@@ -65,12 +65,8 @@ export const providersAdapter: IAdapter = {
         filter: 'meril_scientific_domains',
       },
     ],
-    url: `${
-      ConfigService.config?.marketplace_url
-    }/providers/${encodeURIComponent(provider.pid || '')}`,
-    logoUrl: `${
-      ConfigService.config?.marketplace_url
-    }/providers/${encodeURIComponent(provider.pid || '')}/logo`,
+    url: buildProviderUrl(provider),
+    logoUrl: buildProviderUrl(provider, '/logo'),
     ...parseStatistics(provider),
   }),
 };

--- a/ui/apps/ui/src/app/collections/data/services/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/services/adapter.data.ts
@@ -7,13 +7,13 @@ import {
   toArray,
   toValueWithLabel,
 } from '@collections/filters-serializers/utils';
-import { transformLanguages } from '@collections/data/shared-tags';
+import { transformLanguages } from '../shared-tags';
 import {
   parseStatistics,
   toInterPatternsSecondaryTag,
   toKeywordsSecondaryTag,
-} from '@collections/data/utils';
-import { ConfigService } from '../../../services/config.service';
+} from '../utils';
+import { buildServiceUrl } from '../url-builder-utils';
 
 const setType = (type: string | undefined) => {
   if (type === 'data source') {
@@ -42,15 +42,9 @@ export const servicesAdapter: IAdapter = {
     languages: transformLanguages(service?.language),
     horizontal: service?.horizontal,
     type: setType(service.type),
-    url: `${
-      ConfigService.config?.marketplace_url
-    }/services/${encodeURIComponent(service.pid || '')}`,
-    logoUrl: `${
-      ConfigService.config?.marketplace_url
-    }/services/${encodeURIComponent(service.pid || '')}/logo`,
-    orderUrl: `${
-      ConfigService.config?.marketplace_url
-    }/services/${encodeURIComponent(service.pid || '')}/offers`,
+    url: buildServiceUrl(service),
+    logoUrl: buildServiceUrl(service, '/logo'),
+    orderUrl: buildServiceUrl(service, '/offers'),
     collection: COLLECTION,
     coloredTags: [],
     tags: [

--- a/ui/apps/ui/src/app/collections/data/services/service.model.ts
+++ b/ui/apps/ui/src/app/collections/data/services/service.model.ts
@@ -7,6 +7,7 @@ export interface IService {
   scientific_domains: string[];
   resource_organisation: string;
   pid: string;
+  slug: string;
   best_access_right: string;
   type: string;
   usage_counts_views: string;

--- a/ui/apps/ui/src/app/collections/data/url-builder-utils.ts
+++ b/ui/apps/ui/src/app/collections/data/url-builder-utils.ts
@@ -1,0 +1,172 @@
+import { ConfigService } from '../../services/config.service';
+import { IDataSource } from './data-sources/data-source.model';
+import { IService } from './services/service.model';
+import { IProvider } from './providers/provider.model';
+import { ICatalogue } from './catalogues/catalogue.model';
+import { IBundle } from './bundles/bundle.model';
+import { IOpenAIREResult } from './openair.model';
+import { ITraining } from './trainings/training.model';
+import { IGuideline } from './guidelines/guideline.model';
+
+// Type for entities that can have pid/slug identifiers
+// Using union instead of intersection to avoid conflicting property types
+type IdentifiableEntity = Partial<
+  | IDataSource
+  | IService
+  | IProvider
+  | ICatalogue
+  | IBundle
+  | IOpenAIREResult
+  | ITraining
+  | IGuideline
+> & {
+  pid?: string;
+  slug?: string;
+  id?: string;
+  service_id?: string | number;
+};
+
+/**
+ * Gets the preferred identifier from an entity, falling back from pid to slug
+ */
+export const getEntityIdentifier = (entity: {
+  pid?: string;
+  slug?: string;
+}): string => {
+  return entity.pid || entity.slug || '';
+};
+
+/**
+ * Builds marketplace URLs for different resource types
+ */
+export const buildMarketplaceUrl = (
+  resourceType: 'services' | 'providers' | 'catalogues',
+  identifier: string,
+  path: string = ''
+): string => {
+  const baseUrl = ConfigService.config?.marketplace_url;
+  const encodedIdentifier = encodeURIComponent(identifier);
+  return `${baseUrl}/${resourceType}/${encodedIdentifier}${path}`;
+};
+
+/**
+ * Builds service URLs with pid/slug fallback
+ */
+export const buildServiceUrl = (
+  entity: { pid?: string; slug?: string },
+  path: string = ''
+): string => {
+  const identifier = getEntityIdentifier(entity);
+  return buildMarketplaceUrl('services', identifier, path);
+};
+
+/**
+ * Builds provider URLs with pid/slug fallback
+ */
+export const buildProviderUrl = (
+  entity: { pid?: string; slug?: string },
+  path: string = ''
+): string => {
+  const identifier = getEntityIdentifier(entity);
+  return buildMarketplaceUrl('providers', identifier, path);
+};
+
+/**
+ * Builds catalogue URLs with pid/slug fallback
+ */
+export const buildCatalogueUrl = (
+  entity: { pid?: string; slug?: string },
+  path: string = ''
+): string => {
+  const identifier = getEntityIdentifier(entity);
+  return buildMarketplaceUrl('catalogues', identifier, path);
+};
+
+/**
+ * Gets the main URL for an entity based on its type
+ */
+export const getEntityUrl = (
+  type: string,
+  entity: IdentifiableEntity & { service_id?: string | number; id?: string }
+): string => {
+  switch (type) {
+    case 'dataset':
+    case 'publication':
+    case 'software':
+    case 'other':
+      return `${
+        ConfigService.config?.eosc_explore_url
+      }/search/result?id=${encodeURIComponent(
+        entity.id?.split('|')?.pop() || ''
+      )}`;
+
+    case 'data source':
+    case 'service':
+      return buildServiceUrl(entity);
+
+    case 'bundle':
+      return buildMarketplaceUrl('services', String(entity.service_id || ''));
+
+    case 'provider':
+      return buildProviderUrl(entity);
+
+    case 'catalogue':
+      return buildCatalogueUrl(entity);
+
+    case 'training':
+      return '/trainings/' + encodeURIComponent(entity.id || '');
+
+    case 'interoperability guideline':
+      return '/guidelines/' + encodeURIComponent(entity.id || '');
+
+    default:
+      return '';
+  }
+};
+
+/**
+ * Gets the logo URL for an entity based on its type
+ */
+export const getEntityLogoUrl = (
+  type: string,
+  entity: { pid?: string; slug?: string }
+): string | undefined => {
+  switch (type) {
+    case 'data source':
+    case 'service':
+      return buildServiceUrl(entity, '/logo');
+
+    case 'provider':
+      return buildProviderUrl(entity, '/logo');
+
+    case 'catalogue':
+      return buildCatalogueUrl(entity, '/logo');
+
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * Gets the order URL for an entity based on its type
+ */
+export const getEntityOrderUrl = (
+  type: string,
+  entity: { pid?: string; slug?: string; service_id?: string | number }
+): string | undefined => {
+  switch (type) {
+    case 'data source':
+    case 'service':
+      return buildServiceUrl(entity, '/offers');
+
+    case 'bundle':
+      return buildMarketplaceUrl(
+        'services',
+        String(entity.service_id || ''),
+        '/offers'
+      );
+
+    default:
+      return undefined;
+  }
+};

--- a/ui/apps/ui/src/app/collections/data/url-builder-utils.ts
+++ b/ui/apps/ui/src/app/collections/data/url-builder-utils.ts
@@ -7,6 +7,7 @@ import { IBundle } from './bundles/bundle.model';
 import { IOpenAIREResult } from './openair.model';
 import { ITraining } from './trainings/training.model';
 import { IGuideline } from './guidelines/guideline.model';
+import { IAdapterModel } from './adapters/adapter.model';
 
 // Type for entities that can have pid/slug identifiers
 // Using union instead of intersection to avoid conflicting property types
@@ -19,6 +20,7 @@ type IdentifiableEntity = Partial<
   | IOpenAIREResult
   | ITraining
   | IGuideline
+  | IAdapterModel
 > & {
   pid?: string;
   slug?: string;
@@ -118,6 +120,9 @@ export const getEntityUrl = (
 
     case 'interoperability guideline':
       return '/guidelines/' + encodeURIComponent(entity.id || '');
+
+    case 'adapter':
+      return '/adapters/' + encodeURIComponent(entity?.id || '');
 
     default:
       return '';


### PR DESCRIPTION
closes #1645

Resources onboarded directly in MP doesnt have a PID. We should use PID and fallback to Slug.

PID or Slug collection Scope:
- [x] all collection
- [x] services
- [x] data sources
- [x] providers
- [x] catalogues
- [x] Adapters in all collections are clickable. But they dont have logos and look a little bit different than in /adapters

Repo Scope:
- [x] DH
- [ ] PL DH
