### PR TITLE
fix: [#1632] adapters enhancements

### DIFF
--- a/solr/config/configsets/all_collection_v210/configoverlay.json
+++ b/solr/config/configsets/all_collection_v210/configoverlay.json
@@ -5,4 +5,4 @@
     "_designer.copyFrom":"all_collection_oag56_v205",
     "_designer.enableNestedDocs":false,
     "_designer.languages":[],
-    "_designer.publishedVersion":0}}
+    "_designer.publishedVersion":3}}

--- a/solr/config/configsets/all_collection_v210/managed-schema
+++ b/solr/config/configsets/all_collection_v210/managed-schema
@@ -568,6 +568,7 @@
   <field name="relations" type="strings" uninvertible="true" docValues="true" multiValued="true" indexed="true" stored="true"/>
   <field name="relations_long" type="strings" uninvertible="true" docValues="true" multiValued="true" indexed="true" stored="true"/>
   <field name="releases" type="strings" uninvertible="true" docValues="true" indexed="true" stored="true"/>
+  <field name="repository" type="string" uninvertible="true" docValues="true" indexed="true" stored="true"/>
   <field name="research_community" type="strings" required="false" useDocValuesAsStored="true"/>
   <field name="research_entity_types" type="strings" uninvertible="true" docValues="true" multiValued="true" indexed="true" stored="true"/>
   <field name="research_product_access_policies" type="strings" uninvertible="true" docValues="true" multiValued="true" indexed="true" stored="true"/>

--- a/ui/apps/ui/src/app/collections/data/adapters/adapter.data.ts
+++ b/ui/apps/ui/src/app/collections/data/adapters/adapter.data.ts
@@ -10,6 +10,7 @@ import {
   formatProgrammingLanguage,
   formatPublicationDate,
   parseStatistics,
+  toKeywordsSecondaryTag,
 } from '@collections/data/utils';
 import { ConfigService } from '../../../services/config.service';
 import { IAdapterModel } from '@collections/data/adapters/adapter.model';
@@ -22,13 +23,17 @@ export const adaptersAdapter: IAdapter = {
     title: rawAdapter?.title?.join(' ') || '',
     description: rawAdapter?.description?.join(' ') || '',
     license: formatLicense(rawAdapter?.license),
-    date: formatPublicationDate(rawAdapter.last_update),
+    catalogue: rawAdapter?.catalogues,
+    releases: rawAdapter?.releases,
+    version: rawAdapter?.version,
+    date: formatPublicationDate(rawAdapter.publication_date),
     changelog: rawAdapter?.changelog,
     node: rawAdapter?.node,
     programmingLanguage: formatProgrammingLanguage(
       rawAdapter?.programming_language
     ),
     documentationUrl: rawAdapter?.documentation_url,
+    repository: rawAdapter?.repository,
     logoUrl: rawAdapter?.logo,
     relatedServiceUrl:
       rawAdapter?.related_services && rawAdapter?.related_services?.length > 0
@@ -42,6 +47,11 @@ export const adaptersAdapter: IAdapter = {
         ? '/guidelines/' + encodeURIComponent(rawAdapter.related_guidelines[0])
         : undefined,
     url: '/adapters/' + encodeURIComponent(rawAdapter?.id) || '',
+    collection: COLLECTION,
+    type: {
+      label: rawAdapter?.type || '',
+      value: rawAdapter?.type || '',
+    },
     coloredTags: [],
     tags: [
       {
@@ -60,12 +70,9 @@ export const adaptersAdapter: IAdapter = {
         showMoreThreshold: 4,
       },
     ],
-    type: {
-      label: rawAdapter?.type || '',
-      value: rawAdapter?.type || '',
-    },
-    collection: COLLECTION,
-    secondaryTags: [],
+    secondaryTags: [
+      toKeywordsSecondaryTag(rawAdapter.keywords ?? [], 'keywords'),
+    ],
     ...parseStatistics(rawAdapter),
   }),
 };

--- a/ui/apps/ui/src/app/collections/data/adapters/adapter.model.ts
+++ b/ui/apps/ui/src/app/collections/data/adapters/adapter.model.ts
@@ -1,15 +1,15 @@
 export interface IAdapterModel {
   catalogues: string[];
   changelog: string[];
-  code_repository_url: string;
   description: string[];
   documentation_url: string;
   id: string;
-  last_update: string;
   license: string;
   logo?: string;
   node?: string;
+  publication_date: string;
   programming_language: string;
+  repository: string;
   related_guidelines?: string[];
   related_services?: string[];
   releases: string[];
@@ -17,4 +17,5 @@ export interface IAdapterModel {
   title: string[];
   type: string;
   version: string;
+  keywords?: string[];
 }

--- a/ui/apps/ui/src/app/collections/data/adapters/filters.data.ts
+++ b/ui/apps/ui/src/app/collections/data/adapters/filters.data.ts
@@ -54,5 +54,13 @@ export const adapterFilters: IFiltersConfig = {
       defaultCollapsed: false,
       tooltipText: '',
     },
+    {
+      id: 'keywords',
+      filter: 'keywords',
+      label: 'Keywords',
+      type: 'tag',
+      defaultCollapsed: false,
+      tooltipText: '',
+    },
   ],
 };

--- a/ui/apps/ui/src/app/collections/repositories/types.ts
+++ b/ui/apps/ui/src/app/collections/repositories/types.ts
@@ -69,6 +69,12 @@ export interface IResult {
   changelog?: string[];
   node?: string;
   documentationUrl?: string;
+  repository?: string;
+  keywords?: string[];
+  catalogue?: string[];
+  public_contacts?: string[];
+  releases?: string[];
+  version?: string;
 }
 
 export interface RelatedService {

--- a/ui/apps/ui/src/app/components/repository/repository.component.ts
+++ b/ui/apps/ui/src/app/components/repository/repository.component.ts
@@ -1,16 +1,16 @@
 import { Component, Input } from '@angular/core';
 
 @Component({
-  selector: 'ess-package',
+  selector: 'ess-repository',
   template: `
-    <div>
-      <a href="javascript:void(0)" class="link-package">
+    <div *ngIf="repository">
+      <a [href]="repository" target="_blank" class="link-repository">
         <img
           src="/assets/icon-website.svg"
-          alt="Package"
-          class="package-icon"
+          alt="Repository"
+          class="repository-icon"
         />
-        <span class="package-label">Package</span>
+        <span class="repository-label">{{ title || 'Repository' }}</span>
       </a>
     </div>
   `,
@@ -20,7 +20,7 @@ import { Component, Input } from '@angular/core';
         display: block;
       }
 
-      .link-package {
+      .link-repository {
         display: flex;
         align-items: center;
         text-decoration: none;
@@ -29,19 +29,19 @@ import { Component, Input } from '@angular/core';
         font-weight: 500;
       }
 
-      .package-icon {
+      .repository-icon {
         width: 16px;
         height: 16px;
         margin-right: 4px;
       }
 
-      .package-label {
+      .repository-label {
         line-height: 18px;
       }
     `,
   ],
 })
-export class PackageComponent {
+export class RepositoryComponent {
   @Input() title: string = '';
-  @Input() urls: string[] = [];
+  @Input() repository?: string;
 }

--- a/ui/apps/ui/src/app/components/results-with-pagination/result.component.html
+++ b/ui/apps/ui/src/app/components/results-with-pagination/result.component.html
@@ -347,12 +347,11 @@
       [hasDOIUrl]="hasDOIUrl"
       [exportData]="exportData"
     ></ess-bibliography>
-    <ess-package
+    <ess-repository
       class="bottom-action-link"
-      *ngIf="type.value === 'adapter'"
-      [title]="title"
-      [urls]="urls"
-    ></ess-package>
+      *ngIf="type.value === 'adapter' && repository"
+      [repository]="repository"
+    ></ess-repository>
     <ess-pin
       *ngIf="RESOURCES_TO_SHOW_PIN_TO.includes(type.value)"
       [resourceType]="type.value"

--- a/ui/apps/ui/src/app/components/results-with-pagination/result.component.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/result.component.ts
@@ -49,6 +49,7 @@ export class ResultComponent implements OnInit {
   @Input() url: string = '';
   @Input() logoUrl?: string;
   @Input() orderUrl?: string;
+  @Input() repository?: string;
 
   @Input() isResearchProduct = false;
   @Input() description!: string;

--- a/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.html
+++ b/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.component.html
@@ -227,6 +227,7 @@
           [providerName]="result.providerName ?? []"
           [relatedServices]="result.relatedServices"
           [relatedOrganisations]="result.relatedOrganisations"
+          [repository]="result.repository ?? ''"
         ></ess-result>
       </ng-template>
     </ng-container>

--- a/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.module.ts
+++ b/ui/apps/ui/src/app/components/results-with-pagination/results-with-pagination.module.ts
@@ -26,7 +26,7 @@ import { NzDropDownModule } from 'ng-zorro-antd/dropdown';
 import { ShareModule } from '../../layouts/share/share.module';
 import { PageHeaderModule } from '@components/page-header/page-header.module';
 import { IgServicesCardModule } from '../../layouts/ig-services-card/ig-services-card.module';
-import { PackageComponent } from '../package/package.component';
+import { RepositoryComponent } from '@components/repository/repository.component';
 
 @NgModule({
   declarations: [
@@ -39,7 +39,7 @@ import { PackageComponent } from '../package/package.component';
     ShowRelatedResourceComponent,
     PinStaticComponent,
     SourcesComponent,
-    PackageComponent,
+    RepositoryComponent,
   ],
   imports: [
     CommonModule,

--- a/ui/apps/ui/src/app/pages/adapters-page/adapter-detail-page.component.html
+++ b/ui/apps/ui/src/app/pages/adapters-page/adapter-detail-page.component.html
@@ -32,6 +32,21 @@
               <a href="{{ redirectUrl(adapter?.relatedServiceUrl) }}"> Link</a>
             </dd>
           </dl>
+
+          <!-- Keywords Section -->
+          <div *ngIf="adapter?.secondaryTags?.length" class="keywords-section mt-3">
+            <ng-container *ngFor="let tag of adapter?.secondaryTags">
+              <dl class="mb-1 d-flex" *ngIf="tag?.values?.length">
+                <dt>{{ tag.label || 'Tag' }}</dt>
+                <dd class="keywords-list">
+                  <span *ngFor="let value of tag.values; let last = last" class="keyword-tag">
+                    {{ value.label }}<span *ngIf="!last">, </span>
+                  </span>
+                </dd>
+              </dl>
+            </ng-container>
+          </div>
+
         </div>
       </div>
     </div>
@@ -47,7 +62,7 @@
       </ul>
 
       <div class="description-content mb-4">
-        {{ adapter?.description }}
+        {{ stripHtml(adapter?.description) }}
       </div>
 
       <div class="row description-blocks mb-5">
@@ -62,44 +77,12 @@
               </div>
 
               <ul class="list-unstyled small mb-0">
-                <li><strong>Licence</strong></li>
+                <li class="mt-2"><strong>Version</strong></li>
+                <li>{{ adapter?.version }}</li>
+                <li class="mt-2"><strong>License</strong></li>
                 <li>{{ adapter?.license }}</li>
-                <li class="mt-2"><strong>Publication date</strong></li>
+                <li class="mt-2"><strong>Last update</strong></li>
                 <li>{{ adapter?.date }}</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-md-3">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="card-title">
-                <div class="card-title-icon">
-                  <img src="assets/icon-changelog.svg" alt="Change Log" />
-                </div>
-                <h6 class="card-title fw-bold">Change Log</h6>
-              </div>
-              <ul class="list-unstyled small mb-0">
-                <li *ngFor="let change of adapter?.changelog">{{ change }}</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-md-3">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="card-title">
-                <div class="card-title-icon">
-                  <img src="assets/icon-funding.svg" alt="Funding" />
-                </div>
-                <h6 class="card-title fw-bold">Funding</h6>
-              </div>
-              <ul class="list-unstyled small mb-0">
-                <li>ACC Cyfronet AGH</li>
-                <li>Lorem ipsum dolor</li>
-                <li>ACC Cyfronet AGH</li>
               </ul>
             </div>
           </div>
@@ -121,11 +104,28 @@
                 <li><strong>Node</strong></li>
                 <li>{{ adapter?.node }}</li>
                 <li class="mt-2"><strong>Catalogue</strong></li>
-                <li>Catalogue name</li>
+                <li>{{ adapter?.catalogue }}</li>
               </ul>
             </div>
           </div>
         </div>
+
+        <div class="col-md-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="card-title">
+                <div class="card-title-icon">
+                  <img src="assets/icon-changelog.svg" alt="Change Log" />
+                </div>
+                <h6 class="card-title fw-bold">Change Log</h6>
+              </div>
+              <ul class="list-unstyled small mb-0">
+                <li *ngFor="let change of adapter?.changelog">{{ change }}</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
       </div>
     </div>
 
@@ -133,27 +133,29 @@
       <div class="right-panel-links">
         <ul>
           <li class="package_url">
-            <a class="list-group-item" href="#">Package</a>
+            <a class="list-group-item" href="{{ adapter?.repository }}">Repository</a>
           </li>
           <li class="documentation_url">
-            <a class="list-group-item" href="{{ adapter?.documentationUrl }}"
-              >Documentation</a
-            >
+            <a class="list-group-item" href="{{ adapter?.documentationUrl }}">Documentation</a>
           </li>
           <li class="repository_url">
-            <a class="list-group-item" href="#">Repository</a>
+            <span class="list-group-item">Releases</span>
+            <ul *ngIf="adapter?.releases?.length" class="releases-list">
+              <li *ngFor="let release of adapter?.releases">
+                <a [href]="release" target="_blank">{{ release | sliceRelease }}</a>
+              </li>
+            </ul>
           </li>
         </ul>
       </div>
 
-      <div class="contact-panel mb-5">
+      <div class="contact-panel mb-5" *ngIf="adapter?.public_contacts">
         <div class="card-title">
           <div class="card-title-icon">
             <img src="assets/icon-eye.svg" alt="Contact" />
           </div>
           <h6 class="card-title fw-bold">Contact</h6>
         </div>
-
         <div class="card-body">
           <dl>
             <dt>Maintainers</dt>
@@ -167,10 +169,9 @@
             <dt>Organisation</dt>
             <dd>ACC Cyfronet AGH</dd>
           </dl>
-
-          <a href="#" class="organisation-link" target="_blank"
-            >Organisation URL -></a
-          >
+          <a href="#" class="organisation-link" target="_blank">
+            Organisation URL ->
+          </a>
         </div>
       </div>
     </div>

--- a/ui/apps/ui/src/app/pages/adapters-page/adapter-detail-page.component.scss
+++ b/ui/apps/ui/src/app/pages/adapters-page/adapter-detail-page.component.scss
@@ -253,6 +253,85 @@
   }
 }
 
+.keywords-section dl {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+
+  dt {
+    font-weight: 600;
+    margin-right: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  dd.keywords-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .keyword-tag {
+    background-color: #EDF4FF;
+    color: #010E87;
+    padding: 0.25rem 0.5rem;
+    border-radius: 12px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    display: inline-block;
+    transition: background-color 0.2s, color 0.2s;
+  }
+}
+
+.keywords-section {
+  margin-top: 1rem;
+
+  dt {
+    font-weight: 600;
+    margin-right: 0.5rem;
+  }
+
+  .keywords-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .keyword-tag {
+    background-color: #EDF4FF;
+    color: #010E87;
+    padding: 0.25rem 0.5rem;
+    border-radius: 12px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    display: inline-block;
+    transition: background-color 0.2s, color 0.2s;
+  }
+}
+
+.releases-list {
+  list-style: none;
+  padding-left: 10px;
+  margin-top: 5px;
+}
+
+.releases-list li a {
+  display: block;
+  font-size: 0.9rem;
+  color: #257b85;
+  text-decoration: underline;
+  word-break: break-word;
+}
+
+.releases-list li a:hover {
+  color: #1a5c62;
+}
+
 @media (max-width: 768px) {
 
   .description-body {

--- a/ui/apps/ui/src/app/pages/adapters-page/adapter-detail-page.component.ts
+++ b/ui/apps/ui/src/app/pages/adapters-page/adapter-detail-page.component.ts
@@ -87,4 +87,11 @@ export class AdapterDetailPageComponent implements OnInit {
       urlWithoutQuery.toLowerCase().endsWith(ext)
     );
   }
+
+  stripHtml(html: string | string[] | null | undefined): string {
+    if (!html) return '';
+
+    const str = Array.isArray(html) ? html.join(' ') : html;
+    return str.replace(/<[^>]*>/g, ''); // remove all HTML tags
+  }
 }

--- a/ui/apps/ui/src/app/pages/adapters-page/adapters-page.module.ts
+++ b/ui/apps/ui/src/app/pages/adapters-page/adapters-page.module.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { BackToSearchBarModule } from '@components/back-to-search-bar/back-to-search-bar.module';
 import { IgServicesCardModule } from '../../layouts/ig-services-card/ig-services-card.module';
 import { InteroperabilityGuidelinesPipeModule } from '../../pipe/interoperability-guidelines.pipe.module';
+import { SliceReleasePipe } from '@pages/adapters-page/slice-release.pipe';
 
 @NgModule({
   imports: [
@@ -20,7 +21,7 @@ import { InteroperabilityGuidelinesPipeModule } from '../../pipe/interoperabilit
     InteroperabilityGuidelinesPipeModule,
   ],
 
-  declarations: [AdapterDetailPageComponent],
+  declarations: [AdapterDetailPageComponent, SliceReleasePipe],
   exports: [AdapterDetailPageComponent],
 })
 export class AdaptersPageModule {}

--- a/ui/apps/ui/src/app/pages/adapters-page/slice-release.pipe.ts
+++ b/ui/apps/ui/src/app/pages/adapters-page/slice-release.pipe.ts
@@ -1,0 +1,9 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'sliceRelease' })
+export class SliceReleasePipe implements PipeTransform {
+  transform(value: string): string {
+    const parts = value.split('/');
+    return parts[parts.length - 1];
+  }
+}


### PR DESCRIPTION
closes #1632

Improvements:
List View:
<img width="784" height="454" alt="image" src="https://github.com/user-attachments/assets/89ed3ee0-1381-49c2-9855-bfc256aac5a6" />

Detail View: 
<img width="1385" height="724" alt="image" src="https://github.com/user-attachments/assets/c25725a4-d1a2-4c6a-8bc3-a8e3e864f15d" />

Still missing:
- https://github.com/cyfronet-fid/eosc-search-service/issues/1653
- https://github.com/cyfronet-fid/eosc-search-service/issues/1652

Changes on transformer side
https://github.com/cyfronet-fid/transform-service/pull/71

Adapter's output from solr:
```
{
        "catalogues":["eosc"],
        "changelog":["https://platform.openai.com/"],
        "description":["<p>Test adapter</p>"],
        "documentation_url":["https://platform.openai.com/docs/guides/text?api-mode=responses"],
        "id":"21.15126/CWTM65",
        "keywords":["llm, chatgpt"],
        "license":"adapter_license-apache2",
        "logo":"https://i0.wp.com/www.getautismactive.com/wp-content/uploads/2021/01/Test-Logo-Circle-black-transparent.png?fit=1200%2C1200&ssl=1&w=640",
        "node":"Sandbox",
        "programming_language":"adapter_programming_language-python",
        "related_guidelines":["21.11171/joPIp4"],
        "releases":["https://github.com/cyfronet-fid/eosc-search-service/releases/tag/v2.30.0",
          "https://github.com/cyfronet-fid/eosc-search-service/releases/tag/v2.28.0"],
        "repository":"https://platform.openai.com/",
        "title":["ChatGPT Python Interface"],
        "version":"4",
        "_version_":1841609494544515072,
        "publication_date":"2025-07-07T00:00:00Z",
        "type":"adapter"}
```