### PR TITLE
style: [#1650] go to search topbar background

### DIFF
--- a/ui/apps/ui/src/styles.scss
+++ b/ui/apps/ui/src/styles.scss
@@ -240,7 +240,7 @@ btn-primary.disabled,
   height: 60px !important;
   text-decoration: none;
   font-weight: 100;
-  background: #010B65;
+  background: #010B65 !important;
 }
 
 .suggestions {


### PR DESCRIPTION
close: #1650 

<img width="1684" height="626" alt="image" src="https://github.com/user-attachments/assets/62be75ba-460f-49bb-b96c-5e8dfb2c9a0f" />

Important: need to fix also in MP